### PR TITLE
Expose Kibana Port

### DIFF
--- a/kibana/docker/templates/Dockerfile.j2
+++ b/kibana/docker/templates/Dockerfile.j2
@@ -68,6 +68,6 @@ LABEL org.label-schema.schema-version="1.0" \
   org.label-schema.license="Apache-2.0" \
   org.label-schema.build-date="{{ build_date }}"
 
-
+EXPOSE 5601
 
 CMD ["/usr/local/bin/kibana-docker"]


### PR DESCRIPTION
Since ODFE already defaults to using port 5601, it makes sense to expose the port as well. This resolves issues with users deploying on Docker Swarm, since Docker Swarm does not respect the `expose:` flag on docker stack/compose files.

This allows users to properly use nginx reverse proxying with a `VIRTUAL_PORT=5601` without this change, the nginx container never can properly map to the `5601` port. See https://github.com/jwilder/nginx-proxy/issues/802

I am currently using a proof of concept in production with the simple docker file as:
```
FROM amazon/opendistro-for-elasticsearch-kibana:1.1.0
EXPOSE 5601
```