### PR TITLE
Allow the container to run as non root

### DIFF
--- a/elasticsearch/docker/templates/Dockerfile.j2
+++ b/elasticsearch/docker/templates/Dockerfile.j2
@@ -11,9 +11,9 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Description: 
+# Description:
 # Dockerfile for building the docker image for open distro for elasticsearch
-# 
+#
 # This file was generated from the template at templates/Dockerfile.j2
 
 ################################################################################
@@ -125,7 +125,9 @@ RUN mkdir /usr/share/elasticsearch && \
     chmod 0775 /usr/share/elasticsearch && \
     chgrp 0 /usr/share/elasticsearch
 
-RUN mkdir /usr/share/supervisor
+RUN mkdir /usr/share/supervisor && \
+  chgrp 0 /usr/share/supervisor && \
+  chmod g+w /usr/share/supervisor
 
 WORKDIR /usr/share/elasticsearch
 COPY --from=prep_es_files --chown=1000:0 /usr/share/elasticsearch /usr/share/elasticsearch

--- a/elasticsearch/docker/tests/test_base_os.py
+++ b/elasticsearch/docker/tests/test_base_os.py
@@ -37,3 +37,12 @@ def test_all_elasticsearch_files_are_gid_0(host):
     )
 
     assert host.run(check_for_files_with_gid_0_command).exit_status != 0
+
+
+def test_supervisord_log_dir_is_gid_0_and_writable_for_group(host):
+    check_supervisor_dir_permissions_command = (
+        "find /usr/share -name supervisor -gid 0 -perm -g+w | "
+        "egrep '.*'"
+    )
+
+    assert host.run(check_supervisor_dir_permissions_command).exit_status == 0

--- a/elasticsearch/docker/tests/test_labels.py
+++ b/elasticsearch/docker/tests/test_labels.py
@@ -23,5 +23,5 @@ def test_labels(elasticsearch):
     assert labels['org.label-schema.schema-version'] == '1.0'
     assert labels['org.label-schema.url'] == 'https://opendistro.github.io'
     assert labels['org.label-schema.vcs-url'] == 'https://github.com/opendistro-for-elasticsearch/opendistro-build'
-    assert labels['org.label-schema.version'] == '1.2.0'
+    assert labels['org.label-schema.version'] == '1.2.1'
     assert labels['org.label-schema.license'] == 'Apache-2.0'


### PR DESCRIPTION
## Reason for this PR

When running the container as non root, ie with `securityContext.runAsUser: 1000` the supervisord process was starting up as the passed in user. 
This caused supervisord to fail because the `/usr/share/supervisor` directory was owned by `root`. 

## Fix

I changed the group to guid 0 for `/usr/share/supervisor` and added the group write permissions.

I also had to bump the version in one of tests as it was failing.  