### PR TITLE
Adding the ability to define dedicated Kibana clients.

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -426,6 +426,11 @@ It is then down to the business use-case to decide how data is routed to either 
 
 For supporting automated migration of the data, use the [Elasticsearch Curator](https://github.com/helm/charts/tree/master/stable/elasticsearch-curator)
 
+#### Client.selectorOverride Explanation
+To coincide with the [Hot/Warm Architecture](#hotwarm-architectures), another elasticsearch chart dependency may be added for dedicated Kibana clients to manage queries (separate from the ingestion clients). 
+
+By default, these clients will be added and load balanced via the "client" service. This override allows a separate set of dedicated clients to be deployed for different purposes (E.G. Kibana querying)
+
 #### logging.yml Config
 All values defined under `elasticsearch.loggingConfig` will be converted to yaml and mounted into the config directory.
 
@@ -515,6 +520,7 @@ The following table lists the configurable parameters of the opendistro elastics
 | `elasticsearch.client.ingress.labels`                     | Elasticsearch clients Ingress labels                                                                                                                     | `{}`                                                                    |
 | `elasticsearch.client.livenessProbe`                      | Configuration for the [livenessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/)                     | `[]`                                                                    |
 | `elasticsearch.client.readinessProbe`                     | Configuration for the [readinessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/)                    | `[]`                                                                    |
+| `elasticsearch.client.selectorOverride`                   | Override for selector on client. Explained [here](#clientselectoroverride-explaination)                                                                  | `""`                                                                  |
 | `elasticsearch.client.podDisruptionBudget.enabled`        | If true, create a disruption budget for elasticsearch client                                                                                             | `false`                                                                 |
 | `elasticsearch.client.podDisruptionBudget.minAvailable`   | Minimum number / percentage of pods that should remain scheduled                                                                                         | `1`                                                                     |
 | `elasticsearch.client.podDisruptionBudget.maxUnavailable` | Maximum number / percentage of pods that should remain scheduled                                                                                         | `""`                                                                    |

--- a/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -18,7 +18,7 @@ kind: Deployment
 metadata:
   labels:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
-    role: client
+    role: {{ .Values.elasticsearch.selectorOverride | default "client" | quote }}
   name: {{ template "opendistro-es.fullname" . }}-client
   namespace: {{ .Release.Namespace }}
 spec:
@@ -27,7 +27,7 @@ spec:
     metadata:
       labels:
 {{ include "opendistro-es.labels.standard" . | indent 8 }}
-        role: client
+        role: {{ .Values.elasticsearch.selectorOverride | default "client" | quote }}
       annotations:
         {{/* This forces a restart if the secret config has changed */}}
         {{- if .Values.elasticsearch.config }}
@@ -56,7 +56,7 @@ spec:
                 topologyKey: "kubernetes.io/hostname"
                 labelSelector:
                   matchLabels:
-                    role: client
+                    role: {{ .Values.elasticsearch.selectorOverride | default "client" | quote }}
       {{- with .Values.elasticsearch.client.nodeAffinity }}
         nodeAffinity:
 {{ toYaml . | indent 10 }}
@@ -88,7 +88,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: discovery.seed_hosts
-          value: {{ template "opendistro-es.fullname" . }}-discovery
+          value: {{ .Values.elasticsearch.discoveryOverride | default (printf "%s-discovery" (include "opendistro-es.fullname" .)) | quote }}
         - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:

--- a/helm/opendistro-es/templates/elasticsearch/es-client-pdb.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-pdb.yaml
@@ -29,5 +29,5 @@ spec:
   selector:
     matchLabels:
       app: {{ template "opendistro-es.fullname" . }}
-      role: client
+      role: {{ .Values.elasticsearch.selectorOverride | default "client" | quote }}
 {{- end }}

--- a/helm/opendistro-es/templates/elasticsearch/es-service.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-service.yaml
@@ -20,7 +20,7 @@ metadata:
 {{ toYaml .Values.elasticsearch.client.service.annotations | indent 4 }}
   labels:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
-    role: client
+    role: {{ .Values.elasticsearch.selectorOverride | default "client" | quote }}
   name: {{ template "opendistro-es.fullname" . }}-client-service
   namespace: {{ .Release.Namespace }}
 spec:
@@ -32,6 +32,6 @@ spec:
     - name: metrics
       port: 9600
   selector:
-    role: client
+    role: {{ .Values.elasticsearch.selectorOverride | default "client" | quote }}
   type: {{ .Values.elasticsearch.client.service.type }}
 {{- end }}

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -260,7 +260,8 @@ elasticsearch:
       periodSeconds: 10
     nodeSelector: {}
     podAnnotations: {}
-
+    selectorOverride: ""
+  
   config: {}
     ## Example Config
     # opendistro_security.allow_unsafe_democertificates: false


### PR DESCRIPTION
There's a full discussion on this patch here:

https://github.com/Viasat/opendistro-elastic-community/pull/10

This was completed prior to the helm chart merge. 

This adds the ability to deploy dedicate clients to an existing release.