### PR TITLE
Helm chart best practises and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+Thumbs.db
+.DS_Store
+
+.idea/
+*.iml

--- a/helm/opendistro-es/Chart.yaml
+++ b/helm/opendistro-es/Chart.yaml
@@ -12,7 +12,8 @@
 # permissions and limitations under the License.
 
 apiVersion: v1
-appVersion: 1.0.0
+# Open Distro for Elasticsearch version
+appVersion: 1.3.0
 description: 'Open Distro for Elasticsearch'
 engine: gotpl
 kubeVersion: ^1.10.0-0
@@ -24,4 +25,5 @@ maintainers:
 name: opendistro-es
 sources:
 - https://pages.git.viasat.com/ATG/charts
+# Chart version
 version: 1.3.0

--- a/helm/opendistro-es/Chart.yaml
+++ b/helm/opendistro-es/Chart.yaml
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+apiVersion: v1
 appVersion: 1.0.0
 description: 'Open Distro for Elasticsearch'
 engine: gotpl

--- a/helm/opendistro-es/templates/elasticsearch/elasticsearch-serviceaccount.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/elasticsearch-serviceaccount.yaml
@@ -12,6 +12,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{ if .Values.elasticsearch.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount

--- a/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -130,7 +130,7 @@ spec:
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/logging.yml
           name: config
           subPath: logging.yml
-        {{- if and .Values.elasticsearch.ssl.transport.enabled .Values.elasticsearch.ssl.transport.existingCertSecret }}
+        {{- if .Values.elasticsearch.ssl.transport.existingCertSecret }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-crt.pem
           name: transport-certs
           subPath: elk-transport-crt.pem
@@ -167,7 +167,7 @@ spec:
       - name: config
         secret:
           secretName: {{ template "opendistro-es.fullname" . }}-es-config
-      {{- if and .Values.elasticsearch.ssl.transport.enabled .Values.elasticsearch.ssl.transport.existingCertSecret }}
+      {{- if .Values.elasticsearch.ssl.transport.existingCertSecret }}
       - name: transport-certs
         secret:
           secretName: {{ .Values.elasticsearch.ssl.transport.existingCertSecret }}

--- a/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -12,6 +12,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{- if .Values.elasticsearch.client.enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 
 {{- if .Values.elasticsearch.client.enabled }}
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end }}
     {{- with .Values.elasticsearch.client.affinity }}
       affinity:
-{{- toYaml . | nindent 8 }}
+{{- toYaml . | indent 8 }}
     {{- end }}
       initContainers:
       - name: init-sysctl

--- a/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -51,20 +51,10 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-      # Weighted anti-affinity to disallow deploying client node to the same worker node as master node
+    {{- with .Values.elasticsearch.client.affinity }}
       affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                topologyKey: "kubernetes.io/hostname"
-                labelSelector:
-                  matchLabels:
-                    role: client
-      {{- with .Values.elasticsearch.client.nodeAffinity }}
-        nodeAffinity:
-{{ toYaml . | indent 10 }}
-      {{- end }}
+{{- toYaml . | nindent 8 }}
+    {{- end }}
       initContainers:
       - name: init-sysctl
         image: {{ .Values.elasticsearch.initContainer.image }}:{{ .Values.elasticsearch.initContainer.imageTag }}

--- a/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -23,6 +23,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.elasticsearch.client.replicas }}
+  selector:
+    matchLabels:
+{{ include "opendistro-es.labels.standard" . | indent 6 }}
+      role: client
   template:
     metadata:
       labels:

--- a/helm/opendistro-es/templates/elasticsearch/es-client-ingress.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-ingress.yaml
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{- if and .Values.elasticsearch.client.ingress.enabled .Values.elasticsearch.client.enabled }}
 {{ $fullName := printf "%s-%s"  (include "opendistro-es.fullname" .) "client-service" }}
 {{ $ingressPath := .Values.elasticsearch.client.ingress.path }}

--- a/helm/opendistro-es/templates/elasticsearch/es-client-pdb.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-pdb.yaml
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{- if and .Values.elasticsearch.client.podDisruptionBudget.enabled .Values.elasticsearch.client.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget

--- a/helm/opendistro-es/templates/elasticsearch/es-config-secret.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-config-secret.yaml
@@ -12,6 +12,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/opendistro-es/templates/elasticsearch/es-data-pdb.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-pdb.yaml
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{- if and .Values.elasticsearch.data.podDisruptionBudget.enabled .Values.elasticsearch.data.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget

--- a/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -64,7 +64,7 @@ spec:
           privileged: true
       - name: fixmount
         command: [ 'sh', '-c', 'chown -R 1000:1000 /usr/share/elasticsearch/data' ]
-        image: busybox
+        image: {{ .Values.elasticsearch.initContainer.image }}:{{ .Values.elasticsearch.initContainer.imageTag }}
         volumeMounts:
           - mountPath: /usr/share/elasticsearch/data
             name: data

--- a/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -24,6 +24,10 @@ metadata:
 spec:
   serviceName: {{ template "opendistro-es.fullname" . }}-data-svc
   replicas: {{ .Values.elasticsearch.data.replicas }}
+  selector:
+    matchLabels:
+{{ include "opendistro-es.labels.standard" . | indent 6 }}
+      role: data
   updateStrategy:
     type: {{ .Values.elasticsearch.data.updateStrategy }}
   template:

--- a/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -69,20 +69,10 @@ spec:
           - mountPath: /usr/share/elasticsearch/data
             name: data
             subPath: {{ .Values.elasticsearch.data.persistence.subPath }}
-      # Weighted anti-affinity to disallow deploying client node to the same worker node as master node
+    {{- with .Values.elasticsearch.data.affinity }}
       affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              topologyKey: "kubernetes.io/hostname"
-              labelSelector:
-                matchLabels:
-                  role: data
-      {{- with .Values.elasticsearch.data.nodeAffinity }}
-        nodeAffinity:
-{{ toYaml . | indent 10 }}
-      {{- end }}
+{{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: {{ template "opendistro-es.elasticsearch.serviceAccountName" . }}
       containers:
       - name: elasticsearch

--- a/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 
 {{ if .Values.elasticsearch.data.enabled }}
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:

--- a/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -12,6 +12,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{ if .Values.elasticsearch.data.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet

--- a/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -140,7 +140,7 @@ spec:
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/logging.yml
           name: config
           subPath: logging.yml
-         {{- if and .Values.elasticsearch.ssl.transport.enabled .Values.elasticsearch.ssl.transport.existingCertSecret }}
+        {{- if .Values.elasticsearch.ssl.transport.existingCertSecret }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-crt.pem
           name: transport-certs
           subPath: elk-transport-crt.pem
@@ -177,7 +177,7 @@ spec:
       - name: config
         secret:
           secretName: {{ template "opendistro-es.fullname" . }}-es-config
-      {{- if and .Values.elasticsearch.ssl.transport.enabled .Values.elasticsearch.ssl.transport.existingCertSecret }}
+      {{- if .Values.elasticsearch.ssl.transport.existingCertSecret }}
       - name: transport-certs
         secret:
           secretName: {{ .Values.elasticsearch.ssl.transport.existingCertSecret }}

--- a/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -151,8 +151,8 @@ spec:
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-root-ca.pem
           name: transport-certs
           subPath: elk-transport-root-ca.pem
-         {{- end }}
-         {{- if and .Values.elasticsearch.ssl.rest.enabled .Values.elasticsearch.ssl.rest.existingCertSecret }}
+        {{- end }}
+        {{- if and .Values.elasticsearch.ssl.rest.enabled .Values.elasticsearch.ssl.rest.existingCertSecret }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-crt.pem
           name: rest-certs
           subPath: elk-rest-crt.pem
@@ -162,8 +162,8 @@ spec:
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-root-ca.pem
           name: rest-certs
           subPath: elk-rest-root-ca.pem
-         {{- end }}
-         {{- if and .Values.elasticsearch.ssl.admin.enabled .Values.elasticsearch.ssl.admin.existingCertSecret }}
+        {{- end }}
+        {{- if and .Values.elasticsearch.ssl.admin.enabled .Values.elasticsearch.ssl.admin.existingCertSecret }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-crt.pem
           name: admin-certs
           subPath: admin-crt.pem

--- a/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -68,6 +68,7 @@ spec:
         volumeMounts:
           - mountPath: /usr/share/elasticsearch/data
             name: data
+            subPath: {{ .Values.elasticsearch.data.persistence.subPath }}
       # Weighted anti-affinity to disallow deploying client node to the same worker node as master node
       affinity:
         podAntiAffinity:
@@ -135,6 +136,7 @@ spec:
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/data
           name: data
+          subPath: {{ .Values.elasticsearch.data.persistence.subPath }}
         {{- if .Values.elasticsearch.config }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elasticsearch.yml
           name: config
@@ -200,13 +202,38 @@ spec:
         secret:
           secretName: {{ .Values.elasticsearch.ssl.admin.existingCertSecret }}
       {{- end }}
+      {{- if not .Values.elasticsearch.data.persistence.enabled }}
+      - name: "data"
+        emptyDir: {}
+      {{- else }}
+      {{- if .Values.elasticsearch.data.persistence.existingClaim }}
+      - name: "data"
+        persistentVolumeClaim:
+          claimName: {{ .Values.elasticsearch.data.persistence.existingClaim }}
+      {{- end }}
+      {{- end }}
+  {{- if and .Values.elasticsearch.data.persistence.enabled (not .Values.elasticsearch.data.persistence.existingClaim) }}
   volumeClaimTemplates:
   - metadata:
       name: data
+      annotations:
+      {{- range $key, $value := .Values.elasticsearch.data.persistence.annotations }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
     spec:
-      accessModes: [ ReadWriteOnce ]
-      storageClassName: {{ .Values.elasticsearch.data.storageClassName }}
+      accessModes:
+      {{- range .Values.elasticsearch.data.persistence.accessModes }}
+        - {{ . | quote }}
+      {{- end }}
       resources:
         requests:
-          storage: {{ .Values.elasticsearch.data.storage }}
+          storage: {{ .Values.elasticsearch.data.persistence.size | quote }}
+    {{- if .Values.elasticsearch.data.persistence.storageClass }}
+    {{- if (eq "-" .Values.elasticsearch.data.persistence.storageClass) }}
+      storageClassName: ""
+    {{- else }}
+      storageClassName: "{{ .Values.elasticsearch.data.persistence.storageClass }}"
+    {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -72,7 +72,7 @@ spec:
             subPath: {{ .Values.elasticsearch.data.persistence.subPath }}
     {{- with .Values.elasticsearch.data.affinity }}
       affinity:
-{{- toYaml . | nindent 8 }}
+{{- toYaml . | indent 8 }}
     {{- end }}
       serviceAccountName: {{ template "opendistro-es.elasticsearch.serviceAccountName" . }}
       containers:

--- a/helm/opendistro-es/templates/elasticsearch/es-data-svc.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-svc.yaml
@@ -12,6 +12,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{- if .Values.elasticsearch.data.enabled }}
 apiVersion: v1
 kind: Service

--- a/helm/opendistro-es/templates/elasticsearch/es-master-pdb.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-pdb.yaml
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{- if and .Values.elasticsearch.master.podDisruptionBudget.enabled .Values.elasticsearch.master.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget

--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -77,7 +77,7 @@ spec:
           privileged: true
       - name: fixmount
         command: [ 'sh', '-c', 'chown -R 1000:1000 /usr/share/elasticsearch/data' ]
-        image: busybox
+        image: {{ .Values.elasticsearch.initContainer.image }}:{{ .Values.elasticsearch.initContainer.imageTag }}
         volumeMounts:
           - mountPath: /usr/share/elasticsearch/data
             name: data

--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -81,6 +81,7 @@ spec:
         volumeMounts:
           - mountPath: /usr/share/elasticsearch/data
             name: data
+            subPath: {{ .Values.elasticsearch.master.persistence.subPath }}
       containers:
       - name: elasticsearch
         env:
@@ -146,6 +147,7 @@ spec:
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/data
           name: data
+          subPath: {{ .Values.elasticsearch.master.persistence.subPath }}
         {{- if .Values.elasticsearch.config }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elasticsearch.yml
           name: config
@@ -273,13 +275,38 @@ spec:
         secret:
           secretName: {{ .Values.elasticsearch.securityConfig.tenantsSecret }}
       {{- end }}
+      {{- if not .Values.elasticsearch.master.persistence.enabled }}
+      - name: "data"
+        emptyDir: {}
+      {{- else }}
+      {{- if .Values.elasticsearch.master.persistence.existingClaim }}
+      - name: "data"
+        persistentVolumeClaim:
+          claimName: {{ .Values.elasticsearch.master.persistence.existingClaim }}
+      {{- end }}
+      {{- end }}
+  {{- if and .Values.elasticsearch.master.persistence.enabled (not .Values.elasticsearch.master.persistence.existingClaim) }}
   volumeClaimTemplates:
   - metadata:
       name: data
+      annotations:
+      {{- range $key, $value := .Values.elasticsearch.master.persistence.annotations }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
     spec:
-      accessModes: [ ReadWriteOnce ]
-      storageClassName: {{ .Values.elasticsearch.master.storageClassName }}
+      accessModes:
+      {{- range .Values.elasticsearch.master.persistence.accessModes }}
+        - {{ . | quote }}
+      {{- end }}
       resources:
         requests:
-          storage: {{ .Values.elasticsearch.master.storage }}
+          storage: {{ .Values.elasticsearch.master.persistence.size | quote }}
+    {{- if .Values.elasticsearch.master.persistence.storageClass }}
+    {{- if (eq "-" .Values.elasticsearch.master.persistence.storageClass) }}
+      storageClassName: ""
+    {{- else }}
+      storageClassName: "{{ .Values.elasticsearch.master.persistence.storageClass }}"
+    {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -164,8 +164,8 @@ spec:
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-root-ca.pem
           name: transport-certs
           subPath: elk-transport-root-ca.pem
-         {{- end }}
-         {{- if and .Values.elasticsearch.ssl.rest.enabled .Values.elasticsearch.ssl.rest.existingCertSecret }}
+        {{- end }}
+        {{- if and .Values.elasticsearch.ssl.rest.enabled .Values.elasticsearch.ssl.rest.existingCertSecret }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-crt.pem
           name: rest-certs
           subPath: elk-rest-crt.pem
@@ -186,38 +186,38 @@ spec:
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-root-ca.pem
           name: admin-certs
           subPath: admin-root-ca.pem
-       {{- end }}
-      {{- if .Values.elasticsearch.securityConfig.enabled }}
-      {{- if .Values.elasticsearch.securityConfig.actionGroupsSecret }}
+        {{- end }}
+        {{- if .Values.elasticsearch.securityConfig.enabled }}
+        {{- if .Values.elasticsearch.securityConfig.actionGroupsSecret }}
         - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/action_groups.yml
           name: action-groups
           subPath: action_groups.yml
-       {{- end }}
-       {{- if .Values.elasticsearch.securityConfig.configSecret }}
+        {{- end }}
+        {{- if .Values.elasticsearch.securityConfig.configSecret }}
         - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/config.yml
           name: security-config
           subPath: config.yml
-       {{- end }}
-       {{- if .Values.elasticsearch.securityConfig.internalUsersSecret }}
+        {{- end }}
+        {{- if .Values.elasticsearch.securityConfig.internalUsersSecret }}
         - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/internal_users.yml
           name: internal-users-config
           subPath: internal_users.yml
-       {{- end }}
-       {{- if .Values.elasticsearch.securityConfig.rolesSecret }}
+        {{- end }}
+        {{- if .Values.elasticsearch.securityConfig.rolesSecret }}
         - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/roles.yml
           name: roles
           subPath: roles.yml
-       {{- end }}
-       {{- if .Values.elasticsearch.securityConfig.rolesMappingSecret }}
+        {{- end }}
+        {{- if .Values.elasticsearch.securityConfig.rolesMappingSecret }}
         - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/roles_mapping.yml
           name: role-mapping
           subPath: roles_mapping.yml
-      {{- end }}
-       {{- if .Values.elasticsearch.securityConfig.tenantsSecret }}
+        {{- end }}
+        {{- if .Values.elasticsearch.securityConfig.tenantsSecret }}
         - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/tenants.yml
           name: tenants
           subPath: tenants.yml
-      {{- end }}
+        {{- end }}
       {{- end }}
       volumes:
       - name: config

--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -23,6 +23,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.elasticsearch.master.replicas }}
+  selector:
+    matchLabels:
+{{ include "opendistro-es.labels.standard" . | indent 6 }}
+      role: master
   updateStrategy:
     type: {{ .Values.elasticsearch.master.updateStrategy }}
   serviceName: {{ template "opendistro-es.fullname" . }}-discovery

--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -153,7 +153,7 @@ spec:
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/logging.yml
           name: config
           subPath: logging.yml
-        {{- if and .Values.elasticsearch.ssl.transport.enabled .Values.elasticsearch.ssl.transport.existingCertSecret }}
+        {{- if .Values.elasticsearch.ssl.transport.existingCertSecret }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-crt.pem
           name: transport-certs
           subPath: elk-transport-crt.pem
@@ -222,7 +222,7 @@ spec:
       - name: config
         secret:
           secretName: {{ template "opendistro-es.fullname" . }}-es-config
-      {{- if and .Values.elasticsearch.ssl.transport.enabled .Values.elasticsearch.ssl.transport.existingCertSecret }}
+      {{- if .Values.elasticsearch.ssl.transport.existingCertSecret }}
       - name: transport-certs
         secret:
           secretName: {{ .Values.elasticsearch.ssl.transport.existingCertSecret }}

--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 
 {{- if .Values.elasticsearch.master.enabled }}
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:

--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -57,7 +57,7 @@ spec:
     {{- end }}
     {{- with .Values.elasticsearch.master.affinity }}
       affinity:
-{{- toYaml . | nindent 8 }}
+{{- toYaml . | indent 8 }}
     {{- end }}
       initContainers:
       - name: init-sysctl

--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -12,6 +12,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{- if .Values.elasticsearch.master.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet

--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -54,18 +54,10 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-      # Anti-affinity to disallow deploying client and master nodes on the same worker node
+    {{- with .Values.elasticsearch.master.affinity }}
       affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - topologyKey: "kubernetes.io/hostname"
-            labelSelector:
-              matchLabels:
-                role: master
-      {{- with .Values.elasticsearch.master.nodeAffinity }}
-        nodeAffinity:
-{{ toYaml . | indent 10 }}
-      {{- end }}
+{{- toYaml . | nindent 8 }}
+    {{- end }}
       initContainers:
       - name: init-sysctl
         image: {{ .Values.elasticsearch.initContainer.image }}:{{ .Values.elasticsearch.initContainer.imageTag }}

--- a/helm/opendistro-es/templates/elasticsearch/es-service.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-service.yaml
@@ -12,6 +12,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{- if .Values.elasticsearch.client.enabled }}
 kind: Service
 apiVersion: v1

--- a/helm/opendistro-es/templates/elasticsearch/master-svc.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/master-svc.yaml
@@ -12,6 +12,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{- if .Values.elasticsearch.master.enabled }}
 apiVersion: v1
 kind: Service

--- a/helm/opendistro-es/templates/elasticsearch/role.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/role.yaml
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{- if .Values.global.rbac.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role

--- a/helm/opendistro-es/templates/elasticsearch/rolebinding.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/rolebinding.yaml
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{- if .Values.global.rbac.enabled }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/opendistro-es/templates/kibana/kibana-config-secret.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-config-secret.yaml
@@ -12,6 +12,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{- if and .Values.kibana.enabled .Values.kibana.config }}
 apiVersion: v1
 kind: Secret

--- a/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 
 {{- if .Values.kibana.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
@@ -18,13 +18,19 @@ kind: Deployment
 metadata:
   labels:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
+    role: kibana
   name: {{ template "opendistro-es.fullname" . }}-kibana
 spec:
   replicas: {{ .Values.kibana.replicas }}
+  selector:
+    matchLabels:
+{{ include "opendistro-es.labels.standard" . | indent 6 }}
+      role: kibana
   template:
     metadata:
       labels:
 {{ include "opendistro-es.labels.standard" . | indent 8 }}
+        role: kibana
         app: {{ template "opendistro-es.fullname" . }}-kibana
       annotations:
         {{/* This forces a restart if the secret config has changed */}}

--- a/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
@@ -141,7 +141,7 @@ spec:
     {{- end }}
     {{- with .Values.elasticsearch.client.affinity }}
       affinity:
-{{- toYaml . | nindent 8 }}
+{{- toYaml . | indent 8 }}
     {{- end }}
     {{- with .Values.kibana.tolerations }}
       tolerations:

--- a/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
@@ -12,6 +12,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{- if .Values.kibana.enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
@@ -31,7 +31,6 @@ spec:
       labels:
 {{ include "opendistro-es.labels.standard" . | indent 8 }}
         role: kibana
-        app: {{ template "opendistro-es.fullname" . }}-kibana
       annotations:
         {{/* This forces a restart if the secret config has changed */}}
         {{- if .Values.kibana.config }}

--- a/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
@@ -138,6 +138,10 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.elasticsearch.client.affinity }}
+      affinity:
+{{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.kibana.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/helm/opendistro-es/templates/kibana/kibana-ingress.yml
+++ b/helm/opendistro-es/templates/kibana/kibana-ingress.yml
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{- if and .Values.kibana.ingress.enabled .Values.kibana.enabled }}
 {{- $serviceName:= printf "%s-%s"  (include "opendistro-es.fullname" .) "kibana-svc" }}
 {{- $servicePort := .Values.kibana.externalPort }}

--- a/helm/opendistro-es/templates/kibana/kibana-service.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-service.yaml
@@ -12,6 +12,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{- if .Values.kibana.enabled }}
 apiVersion: v1
 kind: Service

--- a/helm/opendistro-es/templates/kibana/kibana-service.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-service.yaml
@@ -20,6 +20,7 @@ metadata:
 {{ toYaml .Values.kibana.service.annotations | indent 4 }}
   labels:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
+    role: kibana
   name: {{ template "opendistro-es.fullname" . }}-kibana-svc
 spec:
   ports:
@@ -27,6 +28,6 @@ spec:
     port: {{ .Values.kibana.externalPort }}
     targetPort: {{ .Values.kibana.port }}
   selector:
-    app: {{ template "opendistro-es.fullname" . }}-kibana
+    role: kibana
   type: {{ .Values.kibana.service.type }}
 {{- end }}

--- a/helm/opendistro-es/templates/kibana/kibana-serviceaccount.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-serviceaccount.yaml
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{ if and .Values.kibana.serviceAccount.create .Values.kibana.enabled }}
 apiVersion: v1
 kind: ServiceAccount

--- a/helm/opendistro-es/templates/kibana/role.yaml
+++ b/helm/opendistro-es/templates/kibana/role.yaml
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{- if and .Values.global.rbac.enabled .Values.kibana.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role

--- a/helm/opendistro-es/templates/kibana/rolebinding.yaml
+++ b/helm/opendistro-es/templates/kibana/rolebinding.yaml
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{- if and .Values.global.rbac.enabled .Values.kibana.enabled }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/opendistro-es/templates/psp.yml
+++ b/helm/opendistro-es/templates/psp.yml
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 
 {{- if .Values.global.psp.create }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   labels:

--- a/helm/opendistro-es/templates/psp.yml
+++ b/helm/opendistro-es/templates/psp.yml
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# @formatter:off
 {{- if .Values.global.psp.create }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -100,10 +100,10 @@ kibana:
   affinity: {}
 
   serviceAccount:
-    # Specifies whether a ServiceAccount should be created
+    ## Specifies whether a ServiceAccount should be created
     create: true
-    # The name of the ServiceAccount to use.
-    # If not set and create is true, a name is generated using the fullname template
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the fullname template
     name:
 
 
@@ -142,7 +142,7 @@ elasticsearch:
     imageTag: 1.27.2
 
   ssl:
-    # TLS is mandatory for the transport layer and can not be disabled
+    ## TLS is mandatory for the transport layer and can not be disabled
     transport:
       existingCertSecret:
     rest:
@@ -205,7 +205,7 @@ elasticsearch:
       periodSeconds: 10
     nodeSelector: {}
     tolerations: []
-    # Anti-affinity to disallow deploying client and master nodes on the same worker node
+    ## Anti-affinity to disallow deploying client and master nodes on the same worker node
     affinity: {}
     #  podAntiAffinity:
     #    requiredDuringSchedulingIgnoredDuringExecution:
@@ -268,7 +268,7 @@ elasticsearch:
       periodSeconds: 10
     nodeSelector: {}
     tolerations: []
-    # Anti-affinity to disallow deploying client and master nodes on the same worker node
+    ## Anti-affinity to disallow deploying client and master nodes on the same worker node
     affinity: {}
     #  podAntiAffinity:
     #    preferredDuringSchedulingIgnoredDuringExecution:
@@ -333,7 +333,7 @@ elasticsearch:
       periodSeconds: 10
     nodeSelector: {}
     tolerations: []
-    # Weighted anti-affinity to disallow deploying client node to the same worker node as master node
+    ## Weighted anti-affinity to disallow deploying client node to the same worker node as master node
     affinity: {}
     #  podAntiAffinity:
     #    preferredDuringSchedulingIgnoredDuringExecution:
@@ -400,13 +400,13 @@ elasticsearch:
 
   loggingConfig:
     ## Default config
-    # you can override this using by setting a system property, for example -Des.logger.level=DEBUG
+    ## you can override this using by setting a system property, for example -Des.logger.level=DEBUG
     es.logger.level: INFO
     rootLogger: ${es.logger.level}, console
     logger:
-      # log action execution errors for easier debugging
+      ## log action execution errors for easier debugging
       action: DEBUG
-      # reduce the logging for aws, too much is logged under the default INFO
+      ## reduce the logging for aws, too much is logged under the default INFO
       com.amazonaws: WARN
     appender:
       console:
@@ -431,10 +431,10 @@ elasticsearch:
   configDirectory: /usr/share/elasticsearch/config
 
   serviceAccount:
-    # Specifies whether a ServiceAccount should be created
+    ## Specifies whether a ServiceAccount should be created
     create: true
-    # The name of the ServiceAccount to use.
-    # If not set and create is true, a name is generated using the fullname template
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the fullname template
     name:
 
 

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -96,6 +96,7 @@ kibana:
   ##
   tolerations: []
 
+  affinity: {}
 
   serviceAccount:
     # Specifies whether a ServiceAccount should be created
@@ -154,7 +155,6 @@ elasticsearch:
     enabled: true
     replicas: 3
     updateStrategy: "RollingUpdate"
-    nodeAffinity: {}
 
     ## Enable persistence using Persistent Volume Claims
     ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
@@ -196,7 +196,6 @@ elasticsearch:
     podDisruptionBudget:
       enabled: false
       minAvailable: 1
-    tolerations: []
     readinessProbe: []
     livenessProbe:
       tcpSocket:
@@ -204,13 +203,21 @@ elasticsearch:
       initialDelaySeconds: 60
       periodSeconds: 10
     nodeSelector: {}
+    tolerations: []
+    # Anti-affinity to disallow deploying client and master nodes on the same worker node
+    affinity: {}
+    #  podAntiAffinity:
+    #    requiredDuringSchedulingIgnoredDuringExecution:
+    #      - topologyKey: "kubernetes.io/hostname"
+    #        labelSelector:
+    #          matchLabels:
+    #            role: master
     podAnnotations: {}
 
   data:
     enabled: true
     replicas: 3
     updateStrategy: "RollingUpdate"
-    nodeAffinity: {}
 
     ## Enable persistence using Persistent Volume Claims
     ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
@@ -252,7 +259,6 @@ elasticsearch:
     podDisruptionBudget:
       enabled: false
       minAvailable: 1
-    tolerations: []
     readinessProbe: []
     livenessProbe:
       tcpSocket:
@@ -260,6 +266,17 @@ elasticsearch:
       initialDelaySeconds: 60
       periodSeconds: 10
     nodeSelector: {}
+    tolerations: []
+    # Anti-affinity to disallow deploying client and master nodes on the same worker node
+    affinity: {}
+    #  podAntiAffinity:
+    #    preferredDuringSchedulingIgnoredDuringExecution:
+    #      - weight: 1
+    #        podAffinityTerm:
+    #          topologyKey: "kubernetes.io/hostname"
+    #          labelSelector:
+    #            matchLabels:
+    #              role: data
     podAnnotations: {}
 
   client:
@@ -283,7 +300,6 @@ elasticsearch:
         # service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
     replicas: 2
     javaOpts: "-Xms512m -Xmx512m"
-    nodeAffinity: {}
     ingress:
       enabled: true
       annotations: {}
@@ -307,7 +323,6 @@ elasticsearch:
     podDisruptionBudget:
       enabled: false
       minAvailable: 1
-    tolerations: []
     readinessProbe: []
     livenessProbe:
       tcpSocket:
@@ -315,6 +330,17 @@ elasticsearch:
       initialDelaySeconds: 60
       periodSeconds: 10
     nodeSelector: {}
+    tolerations: []
+    # Weighted anti-affinity to disallow deploying client node to the same worker node as master node
+    affinity: {}
+    #  podAntiAffinity:
+    #    preferredDuringSchedulingIgnoredDuringExecution:
+    #      - weight: 1
+    #        podAffinityTerm:
+    #          topologyKey: "kubernetes.io/hostname"
+    #          labelSelector:
+    #            matchLabels:
+    #              role: client
     podAnnotations: {}
 
   config: {}

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -18,13 +18,13 @@ kibana:
   replicas: 1
   port: 5601
   externalPort: 443
-  resources:
-    limits:
-      cpu: 2500m
-      memory: 2Gi
-    requests:
-      cpu: 500m
-      memory: 512Mi
+  resources: {}
+  #  limits:
+  #    cpu: 2500m
+  #    memory: 2Gi
+  #  requests:
+  #    cpu: 500m
+  #    memory: 512Mi
   readinessProbe: []
   livenessProbe: []
 
@@ -51,8 +51,8 @@ kibana:
   ingress:
     enabled: false
     annotations: {}
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
+    #  kubernetes.io/ingress.class: nginx
+    #  kubernetes.io/tls-acme: "true"
     labels: {}
     path: /
     hosts:
@@ -81,8 +81,8 @@ kibana:
     # server.ssl.certificate: /usr/share/kibana/certs/kibana-crt.pem
     # elasticsearch.ssl.certificateAuthorities: /usr/share/kibana/certs/kibana-root-ca.pem
 
-    # opendistro_security.cookie.secure: true
-    # opendistro_security.cookie.password: ${COOKIE_PASS}
+  # opendistro_security.cookie.secure: true
+  # opendistro_security.cookie.password: ${COOKIE_PASS}
 
 
 
@@ -157,13 +157,13 @@ elasticsearch:
     nodeAffinity: {}
     storageClassName: gp2-encrypted
     storage: 50Gi
-    resources:
-      limits:
-        cpu: 1
-        memory: 1024Mi
-      requests:
-        cpu: 200m
-        memory: 1024Mi
+    resources: {}
+    #  limits:
+    #    cpu: 1
+    #    memory: 1024Mi
+    #  requests:
+    #    cpu: 200m
+    #    memory: 1024Mi
     javaOpts: "-Xms512m -Xmx512m"
     podDisruptionBudget:
       enabled: false
@@ -185,13 +185,13 @@ elasticsearch:
     nodeAffinity: {}
     storageClassName: gp2-encrypted
     storage: 100Gi
-    resources:
-      limits:
-        cpu: 1
-        memory: 1024Mi
-      requests:
-        cpu: 200m
-        memory: 1024Mi
+    resources: {}
+    #  limits:
+    #    cpu: 1
+    #    memory: 1024Mi
+    #  requests:
+    #    cpu: 200m
+    #    memory: 1024Mi
     javaOpts: "-Xms512m -Xmx512m"
     podDisruptionBudget:
       enabled: false
@@ -231,8 +231,8 @@ elasticsearch:
     ingress:
       enabled: true
       annotations: {}
-        # kubernetes.io/ingress.class: nginx
-        # kubernetes.io/tls-acme: "true"
+      #  kubernetes.io/ingress.class: nginx
+      #  kubernetes.io/tls-acme: "true"
       labels: {}
       path: /
       hosts:
@@ -241,13 +241,13 @@ elasticsearch:
       #  - secretName: chart-example-tls
       #    hosts:
       #      - chart-example.local
-    resources:
-      limits:
-        cpu: 1
-        memory: 1024Mi
-      requests:
-        cpu: 200m
-        memory: 1024Mi
+    resources: {}
+    #  limits:
+    #    cpu: 1
+    #    memory: 1024Mi
+    #  requests:
+    #    cpu: 200m
+    #    memory: 1024Mi
     podDisruptionBudget:
       enabled: false
       minAvailable: 1

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -153,7 +153,7 @@ elasticsearch:
 
   master:
     enabled: true
-    replicas: 3
+    replicas: 1
     updateStrategy: "RollingUpdate"
 
     ## Enable persistence using Persistent Volume Claims
@@ -216,7 +216,7 @@ elasticsearch:
 
   data:
     enabled: true
-    replicas: 3
+    replicas: 1
     updateStrategy: "RollingUpdate"
 
     ## Enable persistence using Persistent Volume Claims
@@ -298,7 +298,7 @@ elasticsearch:
 
         # # Annotation to create internal only ELB
         # service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
-    replicas: 2
+    replicas: 1
     javaOpts: "-Xms512m -Xmx512m"
     ingress:
       enabled: true

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -141,8 +141,8 @@ elasticsearch:
     imageTag: 1.27.2
 
   ssl:
+    # TLS is mandatory for the transport layer and can not be disabled
     transport:
-      enabled: false
       existingCertSecret:
     rest:
       enabled: false

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -49,6 +49,7 @@ kibana:
   certsDirectory: "/usr/share/kibana/certs"
 
   ingress:
+    ## Set to true to enable ingress record generation
     enabled: false
     annotations: {}
     #  kubernetes.io/ingress.class: nginx
@@ -301,7 +302,8 @@ elasticsearch:
     replicas: 1
     javaOpts: "-Xms512m -Xmx512m"
     ingress:
-      enabled: true
+      ## Set to true to enable ingress record generation
+      enabled: false
       annotations: {}
       #  kubernetes.io/ingress.class: nginx
       #  kubernetes.io/tls-acme: "true"

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -81,8 +81,8 @@ kibana:
     # server.ssl.certificate: /usr/share/kibana/certs/kibana-crt.pem
     # elasticsearch.ssl.certificateAuthorities: /usr/share/kibana/certs/kibana-root-ca.pem
 
-  # opendistro_security.cookie.secure: true
-  # opendistro_security.cookie.password: ${COOKIE_PASS}
+    # opendistro_security.cookie.secure: true
+    # opendistro_security.cookie.password: ${COOKIE_PASS}
 
 
 
@@ -155,8 +155,36 @@ elasticsearch:
     replicas: 3
     updateStrategy: "RollingUpdate"
     nodeAffinity: {}
-    storageClassName: gp2-encrypted
-    storage: 50Gi
+
+    ## Enable persistence using Persistent Volume Claims
+    ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
+    persistence:
+      enabled: true
+      ## A manually managed Persistent Volume and Claim
+      ## Requires persistence.enabled: true
+      ## If defined, PVC must be created manually before volume will be bound
+      ##
+      # existingClaim:
+
+      ## The subdirectory of the volume to mount to, useful in dev environments
+      ## and one PV for multiple services.
+      ##
+      subPath: ""
+
+      ## Open Distro master Persistent Volume Storage Class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If undefined (the default) or set to null, no storageClassName spec is
+      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+      ##   GKE, AWS & OpenStack)
+      ##
+      # storageClass: "-"
+      accessModes:
+        - ReadWriteOnce
+      size: 8Gi
+      annotations: {}
+
     resources: {}
     #  limits:
     #    cpu: 1
@@ -183,8 +211,36 @@ elasticsearch:
     replicas: 3
     updateStrategy: "RollingUpdate"
     nodeAffinity: {}
-    storageClassName: gp2-encrypted
-    storage: 100Gi
+
+    ## Enable persistence using Persistent Volume Claims
+    ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
+    persistence:
+      enabled: true
+      ## A manually managed Persistent Volume and Claim
+      ## Requires persistence.enabled: true
+      ## If defined, PVC must be created manually before volume will be bound
+      ##
+      # existingClaim:
+
+      ## The subdirectory of the volume to mount to, useful in dev environments
+      ## and one PV for multiple services.
+      ##
+      subPath: ""
+
+      ## Open Distro master Persistent Volume Storage Class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If undefined (the default) or set to null, no storageClassName spec is
+      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+      ##   GKE, AWS & OpenStack)
+      ##
+      # storageClass: "-"
+      accessModes:
+        - ReadWriteOnce
+      size: 8Gi
+      annotations: {}
+
     resources: {}
     #  limits:
     #    cpu: 1


### PR DESCRIPTION
Does this PR include tests?

No tests for the Helm chart.

---

Here is a list of changes in this PR:

1) **Added `apiVersion: v1` to `Chart.yaml`, it's a required field**.
2) **Support for Kubernetes 1.16** (contains changes from https://github.com/opendistro-for-elasticsearch/community/pull/143, also can close this issue after merge: https://github.com/opendistro-for-elasticsearch/community/issues/145).
   - Fixed apiVersion for Deployment and StatefulSet, because this version was deprecated and removed in Kubernetes 1.16: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
   - Added selector to Deployment and StatefulSet, which is required with apps/v1 API.
3) **Removed hardcoded `busybox`, use Helm values** (contains changes from https://github.com/opendistro-for-elasticsearch/community/pull/146).
4) **Removed `elasticsearch.ssl.transport.enabled`, it's useless, TLS is mandatory for transport layer**.
4) Helm best practices:
   - Removed hardcoded resources values
   - Improved persistence config and removed hardcoded storage class name
   - More flexible affinity configuration
   - Set minimal replicas count
   - Disable ingress by default