### PR TITLE
added securityConfig config to client & data nodes

### DIFF
--- a/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -169,6 +169,38 @@ spec:
           name: admin-certs
           subPath: admin-root-ca.pem
         {{- end }}
+      {{- if .Values.elasticsearch.securityConfig.enabled }}
+      {{- if .Values.elasticsearch.securityConfig.actionGroupsSecret }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/action_groups.yml
+          name: action-groups
+          subPath: action_groups.yml
+       {{- end }}
+       {{- if .Values.elasticsearch.securityConfig.configSecret }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/config.yml
+          name: security-config
+          subPath: config.yml
+       {{- end }}
+       {{- if .Values.elasticsearch.securityConfig.internalUsersSecret }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/internal_users.yml
+          name: internal-users-config
+          subPath: internal_users.yml
+       {{- end }}
+       {{- if .Values.elasticsearch.securityConfig.rolesSecret }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/roles.yml
+          name: roles
+          subPath: roles.yml
+       {{- end }}
+       {{- if .Values.elasticsearch.securityConfig.rolesMappingSecret }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/roles_mapping.yml
+          name: role-mapping
+          subPath: roles_mapping.yml
+      {{- end }}
+       {{- if .Values.elasticsearch.securityConfig.tenantsSecret }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/tenants.yml
+          name: tenants
+          subPath: tenants.yml
+      {{- end }}
+      {{- end }}
       volumes:
       - name: config
         secret:
@@ -187,5 +219,35 @@ spec:
       - name: admin-certs
         secret:
           secretName: {{ .Values.elasticsearch.ssl.admin.existingCertSecret }}
+      {{- end }}
+      {{- if .Values.elasticsearch.securityConfig.actionGroupsSecret }}
+      - name: action-groups
+        secret:
+          secretName: {{ .Values.elasticsearch.securityConfig.actionGroupsSecret }}
+      {{- end }}
+      {{- if .Values.elasticsearch.securityConfig.configSecret }}
+      - name: security-config
+        secret:
+          secretName: {{ .Values.elasticsearch.securityConfig.configSecret }}
+      {{- end }}
+      {{- if .Values.elasticsearch.securityConfig.internalUsersSecret }}
+      - name: internal-users-config
+        secret:
+          secretName: {{ .Values.elasticsearch.securityConfig.internalUsersSecret }}
+      {{- end }}
+      {{- if .Values.elasticsearch.securityConfig.rolesSecret }}
+      - name: roles
+        secret:
+          secretName: {{ .Values.elasticsearch.securityConfig.rolesSecret }}
+      {{- end }}
+      {{- if .Values.elasticsearch.securityConfig.rolesMappingSecret }}
+      - name: role-mapping
+        secret:
+          secretName: {{ .Values.elasticsearch.securityConfig.rolesMappingSecret }}
+      {{- end -}}
+      {{- if .Values.elasticsearch.securityConfig.tenantsSecret }}
+      - name: tenants
+        secret:
+          secretName: {{ .Values.elasticsearch.securityConfig.tenantsSecret }}
       {{- end }}
 {{- end }}

--- a/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -177,6 +177,38 @@ spec:
           name: admin-certs
           subPath: admin-root-ca.pem
          {{- end }}
+      {{- if .Values.elasticsearch.securityConfig.enabled }}
+      {{- if .Values.elasticsearch.securityConfig.actionGroupsSecret }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/action_groups.yml
+          name: action-groups
+          subPath: action_groups.yml
+       {{- end }}
+       {{- if .Values.elasticsearch.securityConfig.configSecret }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/config.yml
+          name: security-config
+          subPath: config.yml
+       {{- end }}
+       {{- if .Values.elasticsearch.securityConfig.internalUsersSecret }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/internal_users.yml
+          name: internal-users-config
+          subPath: internal_users.yml
+       {{- end }}
+       {{- if .Values.elasticsearch.securityConfig.rolesSecret }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/roles.yml
+          name: roles
+          subPath: roles.yml
+       {{- end }}
+       {{- if .Values.elasticsearch.securityConfig.rolesMappingSecret }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/roles_mapping.yml
+          name: role-mapping
+          subPath: roles_mapping.yml
+      {{- end }}
+       {{- if .Values.elasticsearch.securityConfig.tenantsSecret }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/tenants.yml
+          name: tenants
+          subPath: tenants.yml
+      {{- end }}
+      {{- end }}
       volumes:
       - name: config
         secret:
@@ -195,6 +227,36 @@ spec:
       - name: admin-certs
         secret:
           secretName: {{ .Values.elasticsearch.ssl.admin.existingCertSecret }}
+      {{- end }}
+      {{- if .Values.elasticsearch.securityConfig.actionGroupsSecret }}
+      - name: action-groups
+        secret:
+          secretName: {{ .Values.elasticsearch.securityConfig.actionGroupsSecret }}
+      {{- end }}
+      {{- if .Values.elasticsearch.securityConfig.configSecret }}
+      - name: security-config
+        secret:
+          secretName: {{ .Values.elasticsearch.securityConfig.configSecret }}
+      {{- end }}
+      {{- if .Values.elasticsearch.securityConfig.internalUsersSecret }}
+      - name: internal-users-config
+        secret:
+          secretName: {{ .Values.elasticsearch.securityConfig.internalUsersSecret }}
+      {{- end }}
+      {{- if .Values.elasticsearch.securityConfig.rolesSecret }}
+      - name: roles
+        secret:
+          secretName: {{ .Values.elasticsearch.securityConfig.rolesSecret }}
+      {{- end }}
+      {{- if .Values.elasticsearch.securityConfig.rolesMappingSecret }}
+      - name: role-mapping
+        secret:
+          secretName: {{ .Values.elasticsearch.securityConfig.rolesMappingSecret }}
+      {{- end -}}
+      {{- if .Values.elasticsearch.securityConfig.tenantsSecret }}
+      - name: tenants
+        secret:
+          secretName: {{ .Values.elasticsearch.securityConfig.tenantsSecret }}
       {{- end }}
   volumeClaimTemplates:
   - metadata:


### PR DESCRIPTION
Does this PR include tests?

No tests for the Helm Chart

-----

This PR contains changes to map the securityConfig secrets into the Client and Data nodes. 
This mirrors the configuration already present in the master node configuration.

This addresses the issue raised in #56 
