### PR TITLE
Add check for DISABLE_INSTALL_DEMO_CONFIG

### DIFF
--- a/elasticsearch/docker/build/elasticsearch/bin/docker-entrypoint.sh
+++ b/elasticsearch/docker/build/elasticsearch/bin/docker-entrypoint.sh
@@ -82,7 +82,7 @@ if [[ "$(id -u)" == "0" ]]; then
     fi
 fi
 
-if [[ -d "/usr/share/elasticsearch/plugins/opendistro_security" ]]; then
+if [[ -d "/usr/share/elasticsearch/plugins/opendistro_security" && "$DISABLE_INSTALL_DEMO_CONFIG" != "true" ]]; then
     # Install Demo certifactes for Security Plugin and update the elasticsearch.yml
     # file to use those certificates.
     /usr/share/elasticsearch/plugins/opendistro_security/tools/install_demo_configuration.sh -y -i -s


### PR DESCRIPTION
Fixes https://github.com/opendistro-for-elasticsearch/opendistro-build/issues/10

**This pullrequest needs a test** (and some documentation)

Adds a env-variable in docker entrypoint script to decide whether to execute demo configuration for the security plugin (as it will try to overwrite any existing mounted configuration) 
