### PR TITLE
Bump OpenJDK to 11.0.2 in Docker build

### DIFF
--- a/elasticsearch/docker/templates/Dockerfile.j2
+++ b/elasticsearch/docker/templates/Dockerfile.j2
@@ -37,8 +37,8 @@
 FROM centos:7 AS prep_es_files
 
 ENV PATH /usr/share/elasticsearch/bin:$PATH
-RUN curl -s https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz | tar -C /opt -zxf -
-ENV JAVA_HOME /opt/jdk-11.0.1
+RUN curl -s https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz | tar -C /opt -zxf -
+ENV JAVA_HOME /opt/jdk-11.0.2
 RUN yum install -y unzip
 
 RUN groupadd -g 1000 elasticsearch && \
@@ -110,12 +110,12 @@ RUN yum update -y && \
     yum install -y nc unzip wget which && \
     yum clean all
 COPY CENTOS_LICENSING.txt /root
-COPY --from=prep_es_files --chown=1000:0 /opt/jdk-11.0.1 /opt/jdk-11.0.1
-ENV JAVA_HOME /opt/jdk-11.0.1
+COPY --from=prep_es_files --chown=1000:0 /opt/jdk-11.0.2 /opt/jdk-11.0.2
+ENV JAVA_HOME /opt/jdk-11.0.2
 
 # Replace OpenJDK's built-in CA certificate keystore with the one from the OS
 # vendor. The latter is superior in several ways.
-RUN ln -sf /etc/pki/ca-trust/extracted/java/cacerts /opt/jdk-11.0.1/lib/security/cacerts
+RUN ln -sf /etc/pki/ca-trust/extracted/java/cacerts /opt/jdk-11.0.2/lib/security/cacerts
 
 ENV PATH $PATH:$JAVA_HOME/bin
 


### PR DESCRIPTION
Bump OpenJDK from 11.0.1 to 11.0.2, which fixed [a lot bugs](https://www.oracle.com/technetwork/java/javase/2col/11-0-2-bugfixes-5209269.html).

This will also fix real world issues like [this](https://github.com/grafana/grafana/issues/20944).

## Further more

Since no more point releases of OpenJDK 11 from Oracle, it would be much better for Open Distro for Elasticsearch to use [Amazon Corretto](https://aws.amazon.com/corretto/) instead, with the following options:

1. Build Docker image with `centos:7`, install [the latest version of Amazon Corretto 11](https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/downloads-list.html)

    `https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.tar.gz`

2. Build Docker image with `amazoncorretto:11`