### PR TITLE
Remove erroneous newline removal for affinity settings in helm chart

### DIFF
--- a/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end }}
     {{- with .Values.elasticsearch.client.affinity }}
       affinity:
-{{- toYaml . | indent 8 }}
+{{ toYaml . | indent 8 }}
     {{- end }}
       initContainers:
       - name: init-sysctl

--- a/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -72,7 +72,7 @@ spec:
             subPath: {{ .Values.elasticsearch.data.persistence.subPath }}
     {{- with .Values.elasticsearch.data.affinity }}
       affinity:
-{{- toYaml . | indent 8 }}
+{{ toYaml . | indent 8 }}
     {{- end }}
       serviceAccountName: {{ template "opendistro-es.elasticsearch.serviceAccountName" . }}
       containers:

--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -57,7 +57,7 @@ spec:
     {{- end }}
     {{- with .Values.elasticsearch.master.affinity }}
       affinity:
-{{- toYaml . | indent 8 }}
+{{ toYaml . | indent 8 }}
     {{- end }}
       initContainers:
       - name: init-sysctl

--- a/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
@@ -141,7 +141,7 @@ spec:
     {{- end }}
     {{- with .Values.elasticsearch.client.affinity }}
       affinity:
-{{- toYaml . | indent 8 }}
+{{ toYaml . | indent 8 }}
     {{- end }}
     {{- with .Values.kibana.tolerations }}
       tolerations:


### PR DESCRIPTION
Does this PR include tests?
There are no tests for the helm charts

This PR fixes the template rendering for affinity settings.  Before this PR, if you use the affinity settings, the template renders incorrectly as:

```
      affinity:        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchLabels:
                role: master
            topologyKey: kubernetes.io/hostname
```

After this PR the rendering is fixed to:

```
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchLabels:
                role: master
            topologyKey: kubernetes.io/hostname
```