### PR TITLE
Remove chart label from deployment/sts selector

### DIFF
--- a/helm/opendistro-es/templates/_helpers.tpl
+++ b/helm/opendistro-es/templates/_helpers.tpl
@@ -51,6 +51,16 @@ heritage: "{{ .Release.Service }}"
 {{- end -}}
 
 {{/*
+Define labels for deployment/statefulset selectors.
+We cannot have the chart label here as it will prevent upgrades.
+*/}}
+{{- define "opendistro-es.labels.selector" -}}
+app: {{ template "opendistro-es.fullname" . }}
+release: "{{ .Release.Name }}"
+heritage: "{{ .Release.Service }}"
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "opendistro-es.kibana.serviceAccountName" -}}

--- a/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -26,7 +26,7 @@ spec:
   replicas: {{ .Values.elasticsearch.client.replicas }}
   selector:
     matchLabels:
-{{ include "opendistro-es.labels.standard" . | indent 6 }}
+{{ include "opendistro-es.labels.selector" . | indent 6 }}
       role: client
   template:
     metadata:

--- a/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -27,7 +27,7 @@ spec:
   replicas: {{ .Values.elasticsearch.data.replicas }}
   selector:
     matchLabels:
-{{ include "opendistro-es.labels.standard" . | indent 6 }}
+{{ include "opendistro-es.labels.selector" . | indent 6 }}
       role: data
   updateStrategy:
     type: {{ .Values.elasticsearch.data.updateStrategy }}

--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -26,7 +26,7 @@ spec:
   replicas: {{ .Values.elasticsearch.master.replicas }}
   selector:
     matchLabels:
-{{ include "opendistro-es.labels.standard" . | indent 6 }}
+{{ include "opendistro-es.labels.selector" . | indent 6 }}
       role: master
   updateStrategy:
     type: {{ .Values.elasticsearch.master.updateStrategy }}

--- a/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
@@ -25,7 +25,7 @@ spec:
   replicas: {{ .Values.kibana.replicas }}
   selector:
     matchLabels:
-{{ include "opendistro-es.labels.standard" . | indent 6 }}
+{{ include "opendistro-es.labels.selector" . | indent 6 }}
       role: kibana
   template:
     metadata:


### PR DESCRIPTION
Does this PR include tests?
There are no tests for the helm charts

This PR removes the `chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"` label from the selector for the statefulSets and deployments.  With that label on the selector, upgrading the helm chart to a new version will attempt to alter the selector for the sts/deployments and that field is immutable preventing the upgrade from going through.

For reference, an error similar to this one results when attempting a helm chart upgrade from one version to another with this selector present:

```
Error: rpc error: code = Unknown desc = Deployment.apps "opendistro-es-client" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app":"opendistro-es", "chart":"opendistro-es-1.3.2", "heritage":"Tiller", "release":"opendistro-es", "role":"client"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable && Deployment.apps "opendistro-es-kibana" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app":"opendistro-es", "chart":"opendistro-es-1.3.2", "heritage":"Tiller", "release":"opendistro-es", "role":"kibana"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable && StatefulSet.apps "opendistro-es-data" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden && StatefulSet.apps "opendistro-es-master" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden
```