### PR TITLE
Helm: Updated deprecated resources

### DIFF
--- a/helm/opendistro-es/templates/elasticsearch/es-client-ingress.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-ingress.yaml
@@ -16,7 +16,7 @@
 {{ $fullName := printf "%s-%s"  (include "opendistro-es.fullname" .) "client-service" }}
 {{ $ingressPath := .Values.elasticsearch.client.ingress.path }}
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: {{ $fullName }}
   labels:

--- a/helm/opendistro-es/templates/elasticsearch/role.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/role.yaml
@@ -21,7 +21,7 @@ metadata:
   labels:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
 rules:
-- apiGroups: ['extensions']
+- apiGroups: ['policy']
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:

--- a/helm/opendistro-es/templates/kibana/kibana-ingress.yml
+++ b/helm/opendistro-es/templates/kibana/kibana-ingress.yml
@@ -15,7 +15,7 @@
 {{- if and .Values.kibana.ingress.enabled .Values.kibana.enabled }}
 {{- $serviceName:= printf "%s-%s"  (include "opendistro-es.fullname" .) "kibana-svc" }}
 {{- $servicePort := .Values.kibana.externalPort }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   labels:

--- a/helm/opendistro-es/templates/kibana/role.yaml
+++ b/helm/opendistro-es/templates/kibana/role.yaml
@@ -21,7 +21,7 @@ metadata:
   labels:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
 rules:
-- apiGroups: ['extensions']
+- apiGroups: ['policy']
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:


### PR DESCRIPTION
Updated [deprecated](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) Kubernetes resources that don't work on new releases.