### PR TITLE
Parameterized subPath for certificate secrets

### DIFF
--- a/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -134,35 +134,35 @@ spec:
         {{- if .Values.elasticsearch.ssl.transport.existingCertSecret }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-crt.pem
           name: transport-certs
-          subPath: elk-transport-crt.pem
+          subPath: {{ .Values.elasticsearch.ssl.transport.existingCertSecretCertSubPath }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-key.pem
           name: transport-certs
-          subPath: elk-transport-key.pem
+          subPath: {{ .Values.elasticsearch.ssl.transport.existingCertSecretKeySubPath }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-root-ca.pem
           name: transport-certs
-          subPath: elk-transport-root-ca.pem
+          subPath: {{ .Values.elasticsearch.ssl.transport.existingCertSecretRootCASubPath }}
          {{- end }}
          {{- if and .Values.elasticsearch.ssl.rest.enabled .Values.elasticsearch.ssl.rest.existingCertSecret }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-crt.pem
           name: rest-certs
-          subPath: elk-rest-crt.pem
+          subPath: {{ .Values.elasticsearch.ssl.rest.existingCertSecretCertSubPath }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-key.pem
           name: rest-certs
-          subPath: elk-rest-key.pem
+          subPath: {{ .Values.elasticsearch.ssl.rest.existingCertSecretKeySubPath }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-root-ca.pem
           name: rest-certs
-          subPath: elk-rest-root-ca.pem
+          subPath: {{ .Values.elasticsearch.ssl.rest.existingCertSecretRootCASubPath }}
         {{- end }}
         {{- if and .Values.elasticsearch.ssl.admin.enabled .Values.elasticsearch.ssl.admin.existingCertSecret }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-crt.pem
           name: admin-certs
-          subPath: admin-crt.pem
+          subPath: {{ .Values.elasticsearch.ssl.admin.existingCertSecretCertSubPath }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-key.pem
           name: admin-certs
-          subPath: admin-key.pem
+          subPath: {{ .Values.elasticsearch.ssl.admin.existingCertSecretKeySubPath }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-root-ca.pem
           name: admin-certs
-          subPath: admin-root-ca.pem
+          subPath: {{ .Values.elasticsearch.ssl.admin.existingCertSecretRootCASubPath }}
         {{- end }}
       volumes:
       - name: config

--- a/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -144,35 +144,35 @@ spec:
         {{- if .Values.elasticsearch.ssl.transport.existingCertSecret }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-crt.pem
           name: transport-certs
-          subPath: elk-transport-crt.pem
+          subPath: {{ .Values.elasticsearch.ssl.transport.existingCertSecretCertSubPath }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-key.pem
           name: transport-certs
-          subPath: elk-transport-key.pem
+          subPath: {{ .Values.elasticsearch.ssl.transport.existingCertSecretKeySubPath }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-root-ca.pem
           name: transport-certs
-          subPath: elk-transport-root-ca.pem
+          subPath: {{ .Values.elasticsearch.ssl.transport.existingCertSecretRootCASubPath }}
         {{- end }}
         {{- if and .Values.elasticsearch.ssl.rest.enabled .Values.elasticsearch.ssl.rest.existingCertSecret }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-crt.pem
           name: rest-certs
-          subPath: elk-rest-crt.pem
+          subPath: {{ .Values.elasticsearch.ssl.rest.existingCertSecretCertSubPath }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-key.pem
           name: rest-certs
-          subPath: elk-rest-key.pem
+          subPath: {{ .Values.elasticsearch.ssl.rest.existingCertSecretKeySubPath }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-root-ca.pem
           name: rest-certs
-          subPath: elk-rest-root-ca.pem
+          subPath: {{ .Values.elasticsearch.ssl.rest.existingCertSecretRootCASubPath }}
         {{- end }}
         {{- if and .Values.elasticsearch.ssl.admin.enabled .Values.elasticsearch.ssl.admin.existingCertSecret }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-crt.pem
           name: admin-certs
-          subPath: admin-crt.pem
+          subPath: {{ .Values.elasticsearch.ssl.admin.existingCertSecretCertSubPath }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-key.pem
           name: admin-certs
-          subPath: admin-key.pem
+          subPath: {{ .Values.elasticsearch.ssl.admin.existingCertSecretKeySubPath }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-root-ca.pem
           name: admin-certs
-          subPath: admin-root-ca.pem
+          subPath: {{ .Values.elasticsearch.ssl.admin.existingCertSecretRootCASubPath }}
          {{- end }}
       volumes:
       - name: config

--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -157,35 +157,35 @@ spec:
         {{- if .Values.elasticsearch.ssl.transport.existingCertSecret }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-crt.pem
           name: transport-certs
-          subPath: elk-transport-crt.pem
+          subPath: {{ .Values.elasticsearch.ssl.transport.existingCertSecretCertSubPath }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-key.pem
           name: transport-certs
-          subPath: elk-transport-key.pem
+          subPath: {{ .Values.elasticsearch.ssl.transport.existingCertSecretKeySubPath }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-root-ca.pem
           name: transport-certs
-          subPath: elk-transport-root-ca.pem
+          subPath: {{ .Values.elasticsearch.ssl.transport.existingCertSecretRootCASubPath }}
         {{- end }}
         {{- if and .Values.elasticsearch.ssl.rest.enabled .Values.elasticsearch.ssl.rest.existingCertSecret }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-crt.pem
           name: rest-certs
-          subPath: elk-rest-crt.pem
+          subPath: {{ .Values.elasticsearch.ssl.rest.existingCertSecretCertSubPath }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-key.pem
           name: rest-certs
-          subPath: elk-rest-key.pem
+          subPath: {{ .Values.elasticsearch.ssl.rest.existingCertSecretKeySubPath }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-rest-root-ca.pem
           name: rest-certs
-          subPath: elk-rest-root-ca.pem
+          subPath: {{ .Values.elasticsearch.ssl.rest.existingCertSecretRootCASubPath }}
         {{- end }}
         {{- if and .Values.elasticsearch.ssl.admin.enabled .Values.elasticsearch.ssl.admin.existingCertSecret }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-crt.pem
           name: admin-certs
-          subPath: admin-crt.pem
+          subPath: {{ .Values.elasticsearch.ssl.admin.existingCertSecretCertSubPath }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-key.pem
           name: admin-certs
-          subPath: admin-key.pem
+          subPath: {{ .Values.elasticsearch.ssl.admin.existingCertSecretKeySubPath }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/admin-root-ca.pem
           name: admin-certs
-          subPath: admin-root-ca.pem
+          subPath: {{ .Values.elasticsearch.ssl.admin.existingCertSecretRootCASubPath }}
         {{- end }}
         {{- if .Values.elasticsearch.securityConfig.enabled }}
         {{- if .Values.elasticsearch.securityConfig.actionGroupsSecret }}

--- a/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
@@ -97,24 +97,24 @@ spec:
          {{- if and .Values.kibana.ssl.kibana.enabled .Values.kibana.ssl.kibana.existingCertSecret }}
           - mountPath: {{ .Values.kibana.certsDirectory }}/kibana-crt.pem
             name: kibana-certs
-            subPath: kibana-crt.pem
+            subPath: {{ .Values.kibana.ssl.kibana.existingCertSecretCertSubPath }}
           - mountPath: {{ .Values.kibana.certsDirectory }}/kibana-key.pem
             name: kibana-certs
-            subPath: kibana-key.pem
+            subPath: {{ .Values.kibana.ssl.kibana.existingCertSecretKeySubPath }}
           - mountPath: {{ .Values.kibana.certsDirectory }}/kibana-root-ca.pem
             name: kibana-certs
-            subPath: kibana-root-ca.pem
+            subPath: {{ .Values.kibana.ssl.kibana.existingCertSecretRootCASubPath }}
          {{- end }}
          {{- if and .Values.kibana.ssl.elasticsearch.enabled .Values.kibana.ssl.elasticsearch.existingCertSecret }}
           - mountPath: {{ .Values.kibana.certsDirectory }}/elk-rest-crt.pem
             name: elasticsearch-certs
-            subPath: elk-rest-crt.pem
+            subPath: {{ .Values.kibana.ssl.elasticsearch.existingCertSecretCertSubPath }}
           - mountPath: {{ .Values.kibana.certsDirectory }}/elk-rest-key.pem
             name: elasticsearch-certs
-            subPath: elk-rest-key.pem
+            subPath: {{ .Values.kibana.ssl.elasticsearch.existingCertSecretKeySubPath }}
           - mountPath: {{ .Values.kibana.certsDirectory }}/elk-rest-root-ca.pem
             name: elasticsearch-certs
-            subPath: elk-rest-root-ca.pem
+            subPath: {{ .Values.kibana.ssl.elasticsearch.existingCertSecretRootCASubPath }}
          {{- end }}
         ports:
         - containerPort: {{ .Values.kibana.port }}

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -39,9 +39,15 @@ kibana:
     kibana:
       enabled: false
       existingCertSecret:
+      existingCertSecretCertSubPath: kibana-crt.pem
+      existingCertSecretKeySubPath: kibana-key.pem
+      existingCertSecretRootCASubPath: kibana-root-ca.pem
     elasticsearch:
       enabled: false
       existingCertSecret:
+      existingCertSecretCertSubPath: elk-rest-crt.pem
+      existingCertSecretKeySubPath: elk-rest-key.pem
+      existingCertSecretRootCASubPath: elk-rest-root-ca.pem
 
 
 
@@ -145,12 +151,21 @@ elasticsearch:
     ## TLS is mandatory for the transport layer and can not be disabled
     transport:
       existingCertSecret:
+      existingCertSecretCertSubPath: elk-transport-crt.pem
+      existingCertSecretKeySubPath: elk-transport-key.pem
+      existingCertSecretRootCASubPath: elk-transport-root-ca.pem
     rest:
       enabled: false
       existingCertSecret:
+      existingCertSecretCertSubPath: elk-rest-crt.pem
+      existingCertSecretKeySubPath: elk-rest-key.pem
+      existingCertSecretRootCASubPath: elk-rest-root-ca.pem
     admin:
       enabled: false
       existingCertSecret:
+      existingCertSecretCertSubPath: admin-crt.pem
+      existingCertSecretKeySubPath: admin-key.pem
+      existingCertSecretRootCASubPath: admin-root-ca.pem
 
   master:
     enabled: true


### PR DESCRIPTION
In order to be able to use secrets of type "kubernetes.io/tls" (for example certificates generated with cert-manager) then the default hardcoded subPath values for cert secrets do not work and need to be changed.

This commit updates the templates for es-client, es-data, es-master and kibana deployments/stateful sets and and allows the subPath values to be changed. The "default" value specified in values.yaml is the previous originally hardcoded value.

Does this PR include tests?

This project is developed under a test-driven workflow, so please refrain from submitting patches without test coverage. If you are not familiar with testing in Python, please raise an issue instead.
