### PR TITLE
Srivasri pre install scripts

### DIFF
--- a/elasticsearch/linux_distributions/k-NN-lib-buildscripts/build-kNNlib-deb.sh
+++ b/elasticsearch/linux_distributions/k-NN-lib-buildscripts/build-kNNlib-deb.sh
@@ -28,7 +28,6 @@ sudo git clone https://github.com/nmslib/nmslib.git /usr/share/elasticsearch/nms
 && sudo make \
 && sudo git clone https://github.com/opendistro-for-elasticsearch/k-NN.git /usr/share/elasticsearch/k-NN \
 && cd /usr/share/elasticsearch/k-NN \
-&& sudo git checkout v1.4.0.0 \
 && sudo mkdir /tmp/jni \
 && sudo cp jni/src/v1736/* /tmp/jni \
 && cd /tmp/jni \

--- a/elasticsearch/linux_distributions/k-NN-lib-buildscripts/build-kNNlib-deb.sh
+++ b/elasticsearch/linux_distributions/k-NN-lib-buildscripts/build-kNNlib-deb.sh
@@ -1,0 +1,39 @@
+dpkg-query -W cmake
+if [ "$?" -eq "1" ]
+then
+        exit 1;
+fi
+dpkg-query -W g++
+if [ "$?" -eq "1" ]
+then
+        exit 1;
+fi
+dpkg-query -W git
+if [ "$?" -eq "1" ]
+then
+        exit 1;
+fi
+if [ -z "$JAVA_HOME" ]
+then
+        echo "set JAVA_HOME to the jdk package"
+        exit 1;
+fi
+echo "============================================================================"
+echo "Building library"
+sudo git clone https://github.com/nmslib/nmslib.git /usr/share/elasticsearch/nmslib \
+&& cd /usr/share/elasticsearch/nmslib \
+&& sudo git checkout tags/v1.7.3.6 \
+&& cd similarity_search \
+&& sudo cmake . \
+&& sudo make \
+&& sudo git clone https://github.com/opendistro-for-elasticsearch/k-NN.git /usr/share/elasticsearch/k-NN \
+&& cd /usr/share/elasticsearch/k-NN \
+&& sudo git checkout v1.4.0.0 \
+&& sudo mkdir /tmp/jni \
+&& sudo cp jni/src/v1736/* /tmp/jni \
+&& cd /tmp/jni \
+&& sudo g++ -fPIC -I$JAVA_HOME/include -I$JAVA_HOME/include/linux -I/usr/share/elasticsearch/nmslib/similarity_search/include -std=c++11 -shared -o libKNNIndexV1_7_3_6.so com_amazon_opendistroforelasticsearch_knn_index_v1736_KNNIndex.cpp -lNonMetricSpaceLib -L/usr/share/elasticsearch/nmslib/similarity_search/release \
+&& sudo mv /tmp/jni/libKNNIndexV1_7_3_6.so /usr/lib/ \
+&& sudo rm -rf /usr/share/elasticsearch/nmslib \
+&& sudo rm -rf /usr/share/elasticsearch/k-NN \
+&& exit 0

--- a/elasticsearch/linux_distributions/k-NN-lib-buildscripts/build-kNNlib-rpm.sh
+++ b/elasticsearch/linux_distributions/k-NN-lib-buildscripts/build-kNNlib-rpm.sh
@@ -1,0 +1,43 @@
+echo "preinstall script invoked"
+set a = `sudo yum list installed cmake`
+if [ "$?" -eq "1" ]
+then
+        echo $a
+        exit 1
+fi
+set a = `sudo yum list installed g++`
+if [ "$?" -eq "1" ]
+then
+        echo $a
+        exit 1;
+fi
+set a = `sudo yum list installed git`
+if [ "$?" -eq "1" ]
+then
+        echo $a
+        exit 1
+fi
+if [ -z "$JAVA_HOME" ]
+then
+        echo "set JAVA_HOME to the jdk package"
+        exit 1;
+fi
+echo "============================================================================"
+echo "Building library"
+sudo git clone https://github.com/nmslib/nmslib.git /usr/share/elasticsearch/nmslib
+cd /usr/share/elasticsearch/nmslib
+sudo git checkout tags/v1.7.3.6
+cd similarity_search
+sudo cmake .
+sudo make
+sudo git clone https://github.com/opendistro-for-elasticsearch/k-NN.git /usr/share/elasticsearch/k-NN
+cd /usr/share/elasticsearch/k-NN
+sudo git checkout v1.4.0.0
+sudo mkdir /tmp/jni
+sudo cp jni/src/v1736/* /tmp/jni
+cd /tmp/jni
+sudo g++ -fPIC -I/opt/jdk-12.0.2/include -I/opt/jdk-12.0.2/include/linux -I/usr/share/elasticsearch/nmslib/similarity_search/include -std=c++11 -shared -o libKNNIndexV1_7_3_6.so com_amazon_opendistroforelasticsearch_knn_index_v1736_KNNIndex.cpp -lNonMetricSpaceLib -L/usr/share/elasticsearch/nmslib/similarity_search/release
+sudo mv /tmp/jni/libKNNIndexV1_7_3_6.so /usr/lib/
+sudo rm -rf /usr/share/elasticsearch/nmslib
+sudo rm -rf /usr/share/elasticsearch/k-NN
+exit 0

--- a/elasticsearch/linux_distributions/k-NN-lib-buildscripts/build-kNNlib-rpm.sh
+++ b/elasticsearch/linux_distributions/k-NN-lib-buildscripts/build-kNNlib-rpm.sh
@@ -32,7 +32,6 @@ sudo cmake .
 sudo make
 sudo git clone https://github.com/opendistro-for-elasticsearch/k-NN.git /usr/share/elasticsearch/k-NN
 cd /usr/share/elasticsearch/k-NN
-sudo git checkout v1.4.0.0
 sudo mkdir /tmp/jni
 sudo cp jni/src/v1736/* /tmp/jni
 cd /tmp/jni

--- a/elasticsearch/linux_distributions/scripts/preInstall-deb.sh
+++ b/elasticsearch/linux_distributions/scripts/preInstall-deb.sh
@@ -1,17 +1,5 @@
-echo "preinstall script invoked"
-sudo git clone https://github.com/nmslib/nmslib.git /usr/share/elasticsearch/nmslib
-cd /usr/share/elasticsearch/nmslib 
-sudo git checkout tags/v1.7.3.6 
-cd similarity_search 
-sudo cmake . 
-sudo make 
-sudo git clone https://github.com/opendistro-for-elasticsearch/k-NN.git /usr/share/elasticsearch/k-NN 
-cd /usr/share/elasticsearch/k-NN 
-sudo git checkout v1.4.0.0 
-sudo mkdir /tmp/jni 
-sudo cp jni/src/v1736/* /tmp/jni 
-cd /tmp/jni 
-sudo g++ -fPIC -I/opt/jdk-12.0.2/include -I/opt/jdk-12.0.2/include/linux -I/usr/share/elasticsearch/nmslib/similarity_search/include -std=c++11 -shared -o libKNNIndexV1_7_3_6.so com_amazon_opendistroforelasticsearch_knn_index_v1736_KNNIndex.cpp -lNonMetricSpaceLib -L/usr/share/elasticsearch/nmslib/similarity_search/release 
-sudo mv /tmp/jni/libKNNIndexV1_7_3_6.so /usr/lib/
-sudo rm -rf /usr/share/elasticsearch/nmslib 
-sudo rm -rf /usr/share/elasticsearch/k-NN
+echo "Fetching kNN lib"
+wget https://d3g5vo6xdbdb9a.cloudfront.net/downloads/k-NN-lib/libKNNIndex1_7_3_6.zip \
+&& unzip libKNNIndex1_7_3_6.zip \
+&& sudo mv libKNNIndexV1_7_3_6.so /usr/lib \
+&& rm libKNNIndex1_7_3_6.zip

--- a/elasticsearch/linux_distributions/scripts/preInstall-rpm.sh
+++ b/elasticsearch/linux_distributions/scripts/preInstall-rpm.sh
@@ -1,17 +1,5 @@
-echo "preinstall script invoked"
-sudo git clone https://github.com/nmslib/nmslib.git /usr/share/elasticsearch/nmslib
-cd /usr/share/elasticsearch/nmslib 
-sudo git checkout tags/v1.7.3.6 
-cd similarity_search 
-sudo cmake . 
-sudo make 
-sudo git clone https://github.com/opendistro-for-elasticsearch/k-NN.git /usr/share/elasticsearch/k-NN 
-cd /usr/share/elasticsearch/k-NN 
-sudo git checkout v1.4.0.0 
-sudo mkdir /tmp/jni 
-sudo cp jni/src/v1736/* /tmp/jni 
-cd /tmp/jni 
-sudo g++ -fPIC -I/opt/jdk-12.0.2/include -I/opt/jdk-12.0.2/include/linux -I/usr/share/elasticsearch/nmslib/similarity_search/include -std=c++11 -shared -o libKNNIndexV1_7_3_6.so com_amazon_opendistroforelasticsearch_knn_index_v1736_KNNIndex.cpp -lNonMetricSpaceLib -L/usr/share/elasticsearch/nmslib/similarity_search/release 
-sudo mv /tmp/jni/libKNNIndexV1_7_3_6.so /usr/lib/
-sudo rm -rf /usr/share/elasticsearch/nmslib 
-sudo rm -rf /usr/share/elasticsearch/k-NN
+echo "Fetching kNN lib"
+wget https://d3g5vo6xdbdb9a.cloudfront.net/downloads/k-NN-lib/libKNNIndex1_7_3_6.zip \
+&& unzip libKNNIndex1_7_3_6.zip \
+&& sudo mv libKNNIndexV1_7_3_6.so /usr/lib \
+&& rm libKNNIndex1_7_3_6.zip

--- a/elasticsearch/version.json
+++ b/elasticsearch/version.json
@@ -1,1 +1,1 @@
-{"esversion": "7.4.2", "odVersion": "1.4.0"}
+{"esversion": "7.6.1", "odVersion": "1.6.0"}

--- a/elasticsearch/version.json
+++ b/elasticsearch/version.json
@@ -1,1 +1,1 @@
-{"esversion": "7.6.1", "odVersion": "1.6.0"}
+{"esversion": "7.4.2", "odVersion": "1.4.0"}


### PR DESCRIPTION
Updating the preInstall scripts. Initially the scripts were building the kNN lib on the system. Now the scripts are modified to fetch the prebuilt library from s3 and put it in /usr/lib.
Also build scripts are provided for the deb and rpm users if they wish to build the library locally on the system.