### PR TITLE
Disable telemetry in OD

### DIFF
--- a/kibana/docker/build/kibana/config/kibana.yml
+++ b/kibana/docker/build/kibana/config/kibana.yml
@@ -26,3 +26,9 @@ elasticsearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
 opendistro_security.multitenancy.enabled: true
 opendistro_security.multitenancy.tenants.preferred: ["Private", "Global"]
 opendistro_security.readonly_mode.roles: ["kibana_read_only"]
+
+#Disable telementry default
+telemetry.allowChangingOptInStatus: true
+telemetry.optIn: false
+telemetry.enabled: false
+newsfeed.enabled: false


### PR DESCRIPTION
Disable telemetry for Kibana 7.6 in OD docker.

TODO:
This change needs to be replicated in all the distribution.  More details can be found [here](https://www.elastic.co/guide/en/kibana/current/settings.html)