### PR TITLE
Fix affinity insertion in helm chart

### DIFF
--- a/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end }}
     {{- with .Values.elasticsearch.client.affinity }}
       affinity:
-{{- toYaml . | indent 8 }}
+{{ toYaml . | indent 8 }}
     {{- end }}
       initContainers:
       - name: init-sysctl

--- a/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -72,7 +72,7 @@ spec:
             subPath: {{ .Values.elasticsearch.data.persistence.subPath }}
     {{- with .Values.elasticsearch.data.affinity }}
       affinity:
-{{- toYaml . | indent 8 }}
+{{ toYaml . | indent 8 }}
     {{- end }}
       serviceAccountName: {{ template "opendistro-es.elasticsearch.serviceAccountName" . }}
       containers:

--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -57,7 +57,7 @@ spec:
     {{- end }}
     {{- with .Values.elasticsearch.master.affinity }}
       affinity:
-{{- toYaml . | indent 8 }}
+{{ toYaml . | indent 8 }}
     {{- end }}
       initContainers:
       - name: init-sysctl

--- a/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
@@ -141,7 +141,7 @@ spec:
     {{- end }}
     {{- with .Values.elasticsearch.client.affinity }}
       affinity:
-{{- toYaml . | indent 8 }}
+{{ toYaml . | indent 8 }}
     {{- end }}
     {{- with .Values.kibana.tolerations }}
       tolerations:


### PR DESCRIPTION
If I uncomment "affinity" section in values.yaml it throws an error **"mapping values are not allowed in this context"**.

Example:


        affinity:
          podAntiAffinity:
            requiredDuringSchedulingIgnoredDuringExecution:
              - topologyKey: "kubernetes.io/hostname"
                labelSelector:
                  matchLabels:
                    role: master

P.S. This is duplicate of https://github.com/opendistro-for-elasticsearch/opendistro-build/pull/75