### PR TITLE
Fix the PDB minAvailable reference

### DIFF
--- a/helm/opendistro-es/templates/elasticsearch/es-client-pdb.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-pdb.yaml
@@ -22,7 +22,7 @@ metadata:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
 spec:
 {{- if .Values.elasticsearch.client.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.client.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.elasticsearch.client.podDisruptionBudget.minAvailable }}
 {{- end }}
 {{- if .Values.elasticsearch.client.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.elasticsearch.client.podDisruptionBudget.maxUnavailable }}

--- a/helm/opendistro-es/templates/elasticsearch/es-data-pdb.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-pdb.yaml
@@ -22,7 +22,7 @@ metadata:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
 spec:
 {{- if .Values.elasticsearch.data.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.data.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.elasticsearch.data.podDisruptionBudget.minAvailable }}
 {{- end }}
 {{- if .Values.elasticsearch.data.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.elasticsearch.data.podDisruptionBudget.maxUnavailable }}

--- a/helm/opendistro-es/templates/elasticsearch/es-master-pdb.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-pdb.yaml
@@ -22,7 +22,7 @@ metadata:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
 spec:
 {{- if .Values.elasticsearch.master.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.master.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.elasticsearch.master.podDisruptionBudget.minAvailable }}
 {{- end }}
 {{- if .Values.elasticsearch.master.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.elasticsearch.master.podDisruptionBudget.maxUnavailable }}


### PR DESCRIPTION
The existing PodDisruptionBudget templates seem to have a typo in them for the data path. I think this fixes it (or I've mis-understood how the chart is supposed to work).