### PR TITLE
Windows Zip Bug Fix

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -2,7 +2,7 @@ name: Build Windows Exe using tar artifacts
 
 on:
   schedule:
-    #- cron: '0 10 * * *' Disabling for a bug-fix
+    - cron: '0 10 * * *'
 jobs:
   build-es-artifacts:
     name: Build Windows ES Artifacts
@@ -22,6 +22,7 @@ jobs:
         export JAVA_HOME=/openjdk12
         export PATH=$JAVA_HOME:$PATH
         cd elasticsearch/linux_distributions
+        chmod 755 opendistro-windows-build.sh
         sh ./opendistro-windows-build.sh
         
   build-kibana-artifacts:
@@ -38,7 +39,8 @@ jobs:
     - name: Build Kibana
       run: |
         cd kibana/linux_distributions 
-        sh ./opendistro-windows-kibana-build.sh  
+        chmod 755 opendistro-windows-kibana-build.sh
+        sh ./opendistro-windows-kibana-build.sh
           
   Test-ISM-Plugin:
     needs: [build-es-artifacts, build-kibana-artifacts]
@@ -77,7 +79,7 @@ jobs:
           cd ..\..
           dir
           echo downloading zip from S3 
-          aws s3 cp s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/ode-windows-zip/$S3_PACKAGE .\
+          aws s3 cp s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/staging/odfe-window-zip/$S3_PACKAGE .\
           echo unzipping $S3_PACKAGE
           unzip .\$S3_PACKAGE
           dir
@@ -133,7 +135,7 @@ jobs:
           cd ..\..
           dir
           echo downloading zip from S3 
-          aws s3 cp s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/ode-windows-zip/$S3_PACKAGE .\
+          aws s3 cp s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/staging/odfe-window-zip/$S3_PACKAGE .\
           echo unzipping $S3_PACKAGE
           unzip .\$S3_PACKAGE
           echo "removing security plugin"

--- a/elasticsearch/linux_distributions/opendistro-windows-build.sh
+++ b/elasticsearch/linux_distributions/opendistro-windows-build.sh
@@ -2,28 +2,10 @@
 mkdir ./ws #A temporary workspace inside opendistro-build/elasticsearch/linux_distributions
 ES_VERSION=$(../bin/version-info --es)
 OD_VERSION=$(../bin/version-info --od)
+OD_PLUGINVERSION=$OD_VERSION.0
 PACKAGE=opendistroforelasticsearch
 ROOT=$(dirname "$0")/ws
 TARGET_DIR="$ROOT/Windowsfiles"
- 
-#Downloading tar from s3
-aws s3 cp s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/tarball/opendistro-elasticsearch/$PACKAGE-$OD_VERSION.tar.gz $TARGET_DIR/
-if [ "$?" -eq "1" ]
-then
-  echo "TAR distribution not available"
-  exit 1
-fi
-
-#Untar the tar artifact
-tar -xzf $TARGET_DIR/$PACKAGE-$OD_VERSION.tar.gz --directory $TARGET_DIR
-rm -rf $TARGET_DIR/*.tar.gz
-
-#Remove PA and kNN plugins
-bash $TARGET_DIR/$PACKAGE-$OD_VERSION/bin/elasticsearch-plugin remove opendistro_performance_analyzer
-bash $TARGET_DIR/$PACKAGE-$OD_VERSION/bin/elasticsearch-plugin remove opendistro-knn
-
-#install the certificates
-bash $TARGET_DIR/$PACKAGE-$OD_VERSION/plugins/opendistro_security/tools/install_demo_configuration.sh -y -i -s
 
 #Download windowss oss for copying batch files
 wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$ES_VERSION-windows-x86_64.zip -P $ROOT/
@@ -36,39 +18,33 @@ fi
 #Unzip the oss
 unzip $ROOT/elasticsearch-oss-$ES_VERSION-windows-x86_64.zip -d $ROOT
 rm -rf $ROOT/elasticsearch-oss-$ES_VERSION-windows-x86_64.zip
- 
-#Copy all the bat files in the bin directory
-BAT_FILES=`ls $ROOT/elasticsearch-$ES_VERSION/bin/*.bat`
-cp $BAT_FILES $TARGET_DIR/$PACKAGE-$OD_VERSION/bin
-rm -rf $ROOT/elasticsearch-oss-$ES_VERSION-windows-x86_64
 
+#Install plugins
+for plugin_path in  opendistro-sql/opendistro_sql-$OD_PLUGINVERSION.zip opendistro-alerting/opendistro_alerting-$OD_PLUGINVERSION.zip opendistro-job-scheduler/opendistro-job-scheduler-$OD_PLUGINVERSION.zip opendistro-security/opendistro_security-$OD_PLUGINVERSION.zip opendistro-index-management/opendistro_index_management-$OD_PLUGINVERSION.zip
+do
+  $ROOT/elasticsearch-$ES_VERSION/bin/elasticsearch-plugin install --batch "https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/$plugin_path"
+done
+
+mv $ROOT/elasticsearch-$ES_VERSION $ROOT/$PACKAGE-$OD_VERSION
+cd $ROOT
 #Making zip
-cd $TARGET_DIR
-zip -r ./odfe-$OD_VERSION.zip ./$PACKAGE-$OD_VERSION
-echo inside target
-ls -ltr
-pwd
-cd ../..
-echo inside root
-ls -ltr
-pwd
+zip -r odfe-$OD_VERSION.zip $PACKAGE-$OD_VERSION
 
-#Download install4j software
-wget https://download-gcdn.ej-technologies.com/install4j/install4j_unix_8_0_4.tar.gz -P $ROOT
-#Untar
-tar -xzf $ROOT/install4j_unix_8_0_4.tar.gz --directory $ROOT 
-rm -rf $ROOT/*tar*
-#Download the .install4j file from s3
-aws s3 cp s3://odfe-windows/ODFE.install4j $ROOT
+##Build Exe
+wget https://download-gcdn.ej-technologies.com/install4j/install4j_unix_8_0_4.tar.gz
+tar -xzf install4j_unix_8_0_4.tar.gz
+aws s3 cp s3://odfe-windows/ODFE.install4j .
 if [ "$?" -eq "1" ]
 then
   echo "Install4j not available"
   exit 1
 fi
-#Build the exe
-$ROOT/install4j*/bin/install4jc -d $TARGET_DIR/EXE -D sourcedir=./Windowsfiles/$PACKAGE-$OD_VERSION,version=$OD_VERSION --license=L-M8-AMAZON_DEVELOPMENT_CENTER_INDIA_PVT_LTD#50047687020001-3rhvir3mkx479#484b6 $ROOT/ODFE.install4j
+pwd
 
-#Copy to s3
-aws s3 cp $TARGET_DIR/EXE/*.exe s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/odfe-executables/
-aws s3 cp $TARGET_DIR/odfe-$OD_VERSION.zip s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/ode-windows-zip/
-rm -rf ws
+#Build the exe
+install4j8.0.4/bin/install4jc -d EXE -D sourcedir=./$PACKAGE-$OD_VERSION,version=$OD_VERSION --license="L-M8-AMAZON_DEVELOPMENT_CENTER_INDIA_PVT_LTD#50047687020001-3rhvir3mkx479#484b6" ./ODFE.install4j
+
+#upload top S3
+aws s3 cp EXE/*.exe s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/staging/odfe-executable/
+aws s3 cp odfe-$OD_VERSION.zip s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/staging/odfe-window-zip/
+aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"

--- a/kibana/linux_distributions/opendistro-windows-kibana-build.sh
+++ b/kibana/linux_distributions/opendistro-windows-kibana-build.sh
@@ -70,6 +70,7 @@ ls -ltr $TARGET_DIR
 $ROOT/install4j*/bin/install4jc -d $TARGET_DIR/EXE -D sourcedir=./Windowsfiles/$PACKAGE,version=$OD_VERSION --license=L-M8-AMAZON_DEVELOPMENT_CENTER_INDIA_PVT_LTD#50047687020001-3rhvir3mkx479#484b6 $ROOT/ODFE-Kibana.install4j
 
 #Copy to s3
-aws s3 cp $TARGET_DIR/EXE/*.exe s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/odfe-executables/
-aws s3 cp $TARGET_DIR/odfe-$OD_VERSION-kibana.zip s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/ode-windows-zip/
+aws s3 cp $TARGET_DIR/EXE/*.exe s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/staging/odfe-executable/
+aws s3 cp $TARGET_DIR/odfe-$OD_VERSION-kibana.zip s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/staging/odfe-window-zip/
+aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"
 rm -rf ws


### PR DESCRIPTION
Instead of copying "bat" files from odfe tar, we are downloading windows oss zip from elastic repo, install plugins and uploading opendistro zip to staging repo. 