### PR TITLE
Simplify security secrets configurations

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -255,32 +255,32 @@ you can define secrets that map to each config given that each secret contains t
 securityConfig:
   enabled: true
   path: "/usr/share/elasticsearch/plugins/opendistro_security/securityconfig"
-  actionGroupsSecret:
-  configSecret:
-  internalUsersSecret:
-  rolesSecret:
-  rolesMappingSecret:
+  config: {}
+    # config.yml: |-
+    # internal_users.yml: |-
+    # roles.yml: |-
+    # rolesMapping.yml: |-
+    # tenants.yml: |-
 ```
 Example:
 ```
-❯ cat config.yml
-_meta:
-  type: "config"
-  config_version: 2
-config:
-  dynamic:
-    filtered_alias_mode: "warn"
-    disable_rest_auth: false
-    disable_intertransport_auth: false
-    respect_request_indices_options: false
-    license: null
-    kibana:
-      multitenancy_enabled: true
+config.yml: |-
+  _meta:
+    type: "config"
+    config_version: 2
+  config:
+    dynamic:
+      filtered_alias_mode: "warn"
+      disable_rest_auth: false
+      disable_intertransport_auth: false
+      respect_request_indices_options: false
+      license: null
+      kibana:
+        multitenancy_enabled: true
 .......
-❯ kubectl create secret generic -n logging security-config --from-file=config.yml
+
 ```
-By coupling the above secrets with `opendistro_security.allow_default_init_securityindex: true` in your
-`elasticsearch.config:` at startup all of the secrets will be mounted in and read.
+
 
 Alternatively you can set `securityConfig.enabled` to `false` and `exec` into the container and make changes as you see fit using the instructions
 [here](https://github.com/opendistro-for-elasticsearch/security/blob/master/securityconfig/elasticsearch.yml.example)
@@ -558,4 +558,3 @@ The following table lists the configurable parameters of the opendistro elastics
 
 ## Acknowledgements
 * [Kalvin Chau](https://github.com/kalvinnchau) (Software Engineer - Viasat) for all his help with the Kubernetes internals, certs, and debugging
-

--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -188,35 +188,9 @@ spec:
           subPath: admin-root-ca.pem
         {{- end }}
         {{- if .Values.elasticsearch.securityConfig.enabled }}
-        {{- if .Values.elasticsearch.securityConfig.actionGroupsSecret }}
-        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/action_groups.yml
-          name: action-groups
-          subPath: action_groups.yml
-        {{- end }}
-        {{- if .Values.elasticsearch.securityConfig.configSecret }}
-        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/config.yml
+        {{- if .Values.elasticsearch.securityConfig.config }}
+        - mountPath: {{ .Values.elasticsearch.securityConfig.path }} 
           name: security-config
-          subPath: config.yml
-        {{- end }}
-        {{- if .Values.elasticsearch.securityConfig.internalUsersSecret }}
-        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/internal_users.yml
-          name: internal-users-config
-          subPath: internal_users.yml
-        {{- end }}
-        {{- if .Values.elasticsearch.securityConfig.rolesSecret }}
-        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/roles.yml
-          name: roles
-          subPath: roles.yml
-        {{- end }}
-        {{- if .Values.elasticsearch.securityConfig.rolesMappingSecret }}
-        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/roles_mapping.yml
-          name: role-mapping
-          subPath: roles_mapping.yml
-        {{- end }}
-        {{- if .Values.elasticsearch.securityConfig.tenantsSecret }}
-        - mountPath: {{ .Values.elasticsearch.securityConfig.path }}/tenants.yml
-          name: tenants
-          subPath: tenants.yml
         {{- end }}
       {{- end }}
       volumes:
@@ -238,35 +212,10 @@ spec:
         secret:
           secretName: {{ .Values.elasticsearch.ssl.admin.existingCertSecret }}
       {{- end }}
-      {{- if .Values.elasticsearch.securityConfig.actionGroupsSecret }}
-      - name: action-groups
-        secret:
-          secretName: {{ .Values.elasticsearch.securityConfig.actionGroupsSecret }}
-      {{- end }}
-      {{- if .Values.elasticsearch.securityConfig.configSecret }}
+      {{- if .Values.elasticsearch.securityConfig.config }}
       - name: security-config
         secret:
-          secretName: {{ .Values.elasticsearch.securityConfig.configSecret }}
-      {{- end }}
-      {{- if .Values.elasticsearch.securityConfig.internalUsersSecret }}
-      - name: internal-users-config
-        secret:
-          secretName: {{ .Values.elasticsearch.securityConfig.internalUsersSecret }}
-      {{- end }}
-      {{- if .Values.elasticsearch.securityConfig.rolesSecret }}
-      - name: roles
-        secret:
-          secretName: {{ .Values.elasticsearch.securityConfig.rolesSecret }}
-      {{- end }}
-      {{- if .Values.elasticsearch.securityConfig.rolesMappingSecret }}
-      - name: role-mapping
-        secret:
-          secretName: {{ .Values.elasticsearch.securityConfig.rolesMappingSecret }}
-      {{- end -}}
-      {{- if .Values.elasticsearch.securityConfig.tenantsSecret }}
-      - name: tenants
-        secret:
-          secretName: {{ .Values.elasticsearch.securityConfig.tenantsSecret }}
+          secretName: {{ template "opendistro-es.fullname" . }}-es-config-secrets
       {{- end }}
       {{- if not .Values.elasticsearch.master.persistence.enabled }}
       - name: "data"

--- a/helm/opendistro-es/templates/elasticsearch/es-security-config.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-security-config.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.elasticsearch.securityConfig.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "opendistro-es.fullname" . }}-es-config-secrets
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+type: Opaque
+data:
+{{- if .Values.elasticsearch.securityConfig.config }}
+{{- range $key, $val := .Values.elasticsearch.securityConfig.config }}
+  {{ $key }}: {{ $val | b64enc | quote }}
+{{- end }}
+{{- end }}
+{{- end}}

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -128,12 +128,12 @@ elasticsearch:
   securityConfig:
     enabled: true
     path: "/usr/share/elasticsearch/plugins/opendistro_security/securityconfig"
-    actionGroupsSecret:
-    configSecret:
-    internalUsersSecret:
-    rolesSecret:
-    rolesMappingSecret:
-    tenantsSecret:
+    config: {}
+      # config.yml: |-
+      # internal_users.yml: |-
+      # roles.yml: |-
+      # rolesMapping.yml: |-
+      # tenants.yml: |-
 
   extraEnvs: []
 


### PR DESCRIPTION
This PR simplifies  security secrets configurations. It allows users to specify the values of  config.yml, action_groups.yml, internal_users.yml, roles.yml, roles_mapping.yml  in values.yaml file instead of creating different secrets for each. 