### PR TITLE
Modify check_plugin.yml to use user assigned values and chime message

### DIFF
--- a/.github/workflows/check_plugin.yml
+++ b/.github/workflows/check_plugin.yml
@@ -1,4 +1,4 @@
-name: Check Plugin All Availability
+name: Check Plugin Availability
 
 on:
   # schedule:
@@ -7,9 +7,15 @@ on:
   repository_dispatch:
     types: [check_plugin]
 
+  push:
+    branches: [opendistro-infra-issue-88-2]
+
+env:
+  CHIME_MESSAGE: check_availability pipeline errors
+
 jobs:
   plugin-avilability:
-    name: Check Plugin All Availability
+    name: Check Plugin Availability
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -20,6 +26,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Checking Availability
+        env:
+          PLUGIN_TYPES: undefined
+          ODFE_VERSION: undefined
         run: |
           #!/bin/bash
           CURRENT_NO_PLUGINS="8 10 10"
@@ -28,8 +37,33 @@ jobs:
           S3_URL_zip="${S3_URL_base}/elasticsearch-plugins"
           S3_URL_rpm="${S3_URL_base}/rpms"
           S3_URL_deb="${S3_URL_base}/debs"
-          PLUGIN_TYPES="zip rpm deb"
+          TSCRIPT_NEWLINE="%0D%0A"
+          RUN_STATUS=0 # 0 is success, 1 is failure
+
+          # Allow user assignment
+          echo "#######################################"
+          echo "PLUGIN_TYPES is: $PLUGIN_TYPES"
+          if [[ $PLUGIN_TYPES == "undefined" ]]
+          then
+            PLUGIN_TYPES="zip rpm deb"
+            echo "Use default PLUGIN_TYPES: $PLUGIN_TYPES"
+          fi
           PLUGIN_TYPES=`echo $PLUGIN_TYPES | tr '[:upper:]' '[:lower:]'`
+          echo "#######################################"
+
+          # Allow user assignment
+          echo "ODFE_VERSION is: $ODFE_VERSION"
+
+          if [[ $ODFE_VERSION == "undefined" ]]
+          then
+            cd $CURRENT_DIR/elasticsearch/bin
+            ls -lrt
+            ODFE_VERSION=`./version-info --od`
+            ./version-info --od
+            echo "Use default ODFE_VERSION: $ODFE_VERSION"
+          fi
+          echo "#######################################"
+
 
           PLUGINS_zip="opendistro-alerting/opendistro_alerting \
                        opendistro-anomaly-detection/opendistro-anomaly-detection \
@@ -78,13 +112,6 @@ jobs:
             echo $S3_URL
             echo $PLUGINS | tr " " "\n"
             echo "#######################################"
-  
-            cd $CURRENT_DIR/elasticsearch/bin
-            ls -ltr
-            echo "#######################################"
-            OD_VERSION=`./version-info --od`
-            echo "OD version: $OD_VERSION"
-            echo "#######################################"
             cd /home/runner/work/opendistro-build
             rm -rf plugins
             mkdir -p plugins
@@ -97,7 +124,7 @@ jobs:
               plugin_folder=`echo $item|awk -F/ '{print $1}'`
               plugin_item=`echo $item|awk -F/ '{print $2}'`
               plugin_arr+=( $plugin_item )
-              plugin_artifact="${plugin_item}[_-]${OD_VERSION}.*${plugin_type}"
+              plugin_artifact="${plugin_item}[_-]${ODFE_VERSION}.*${plugin_type}"
               aws s3 cp "${S3_URL}/${plugin_folder}/" . --recursive --exclude "*" --include "${plugin_artifact}" --quiet
             done
             echo "#######################################"
@@ -122,46 +149,69 @@ jobs:
   
             cd /home/runner/work/opendistro-build/opendistro-build/
   
-            echo "<h1><u>ES Plugins ($OD_VERSION) Availability Checks for ($plugin_type)</u></h1>" >> message.md
+            echo "<h1><u>ES Plugins ($ODFE_VERSION) Availability Checks for ($plugin_type)</u></h1>" >> message.md
+            echo "ES Plugins ($ODFE_VERSION) Availability Checks for ($plugin_type): $TSCRIPT_NEWLINE" >> chime_message.md
             
-            echo "<h2>Below plugins are <b>not available</b> for ODFE-$OD_VERSION build</h2>" >> message.md
+            echo "<h2><p style='color:red;'>Below plugins are <b>NOT available</b> for ODFE-$ODFE_VERSION build:</p></h2>" >> message.md
             if [ ${#unavailable_plugin[*]} -gt 0 ]
             then
+                RUN_STATUS=1
                 echo "<ol>" >> message.md
                 for item in ${unavailable_plugin[*]}
                 do
                   echo "<li><h3>$item</h3></li>" >> message.md
+                  echo ":x: $item $TSCRIPT_NEWLINE" >> chime_message.md
                 done
                 echo "</ol>" >> message.md
                 echo "<br><br>" >> message.md
             fi
             
-            echo "<h2>Below plugins are <b>available</b> for ODFE-$OD_VERSION build</h2>" >> message.md
+            echo "<h2><p style='color:green;'>Below plugins are <b>available</b> for ODFE-$ODFE_VERSION build:</p></h2>" >> message.md
             if [ ${#available_plugin[*]} -gt 0 ]
             then
                 echo "<ol>" >> message.md
                 for item in ${available_plugin[*]}
                 do
                   echo "<li><h3>$item</h3></li>" >> message.md
+                  echo ":white_check_mark: $item $TSCRIPT_NEWLINE" >> chime_message.md
                 done
                 echo "</ol>" >> message.md
                 echo "<br><br>" >> message.md
             fi
+            echo "<br><br>" >> message.md
+            echo "$TSCRIPT_NEWLINE" >> chime_message.md
 
           # plugin_type
           done
 
-      - name: Send mail
-        uses: dawidd6/action-send-mail@master
+          echo ::set-env name=CHIME_MESSAGE::$(cat chime_message.md)
+
+          # Use status to decide a success or failure run
+          if [ $RUN_STATUS == 1 ]
+          then
+            echo "You have one or more plugins not available. Exit 1"
+            exit 1
+          fi
+
+      - name: Send Chime Message
+        if: ${{ always() }}
+        uses: ros-tooling/action-amazon-chime@master
         with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{secrets.MAIL_USERNAME}}
-          password: ${{secrets.MAIL_PASSWORD}}
-          subject: Opendistro for Elasticsearch Build - Daily Run (Plugin Status)
-          # Read file contents as body:
-          body: file://message.md
-          to: sngri@amazon.com,odfe-distribution-build@amazon.com
-          from: Opendistro Elasticsearch
-          # Optional content type:
-          content_type: text/html
+          message: ${{ env.CHIME_ODFE_RELEASE }}
+          webhook: ${{ secrets.CHIME_TEST_MESSAGE }}
+
+      #- name: Send mail
+        #if: ${{ always() }}
+        #uses: dawidd6/action-send-mail@master
+        #with:
+          #server_address: smtp.gmail.com
+          #server_port: 465
+          #username: ${{secrets.MAIL_USERNAME}}
+          #password: ${{secrets.MAIL_PASSWORD}}
+          #subject: Opendistro for Elasticsearch Build - Daily Run (Plugin Status)
+          ## Read file contents as body:
+          #body: file://message.md
+          #to: sngri@amazon.com,odfe-distribution-build@amazon.com
+          #from: Opendistro Elasticsearch
+          ## Optional content type:
+          #content_type: text/html

--- a/.github/workflows/check_plugin.yml
+++ b/.github/workflows/check_plugin.yml
@@ -197,8 +197,8 @@ jobs:
         if: ${{ always() }}
         uses: ros-tooling/action-amazon-chime@master
         with:
-          message: ${{ env.CHIME_ODFE_RELEASE }}
-          webhook: ${{ secrets.CHIME_TEST_MESSAGE }}
+          message: ${{ env.CHIME_MESSAGE }}
+          webhook: ${{ secrets.CHIME_ODFE_RELEASE }}
 
       #- name: Send mail
         #if: ${{ always() }}


### PR DESCRIPTION
This PR is to tweak check_plugin.yml so that it can switch targets based on user defined env var PLUGIN_TYPES. It is required for the next improved step of check within build scripts to work.

It can now properly detect the status of a plugin check. If all the necessary plugins are available, return success; else, return failure. The email will still be sent to corresponding teams.

1.7.0 success case:
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/108636259

1.8.0 failure case:
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/108631070

The test will show as failure, which is expected, as currently 1.8.0 plugins are not out yet.
Please use the tests above as part of verification.

Thanks.
