### PR TITLE
Modify check_plugin.yml to use user assigned values and chime message (2)

### DIFF
--- a/.github/workflows/check_plugin.yml
+++ b/.github/workflows/check_plugin.yml
@@ -1,15 +1,21 @@
-name: Check Plugin All Availability
+name: Check Plugin Availability
 
 on:
-  # schedule:
-  #   - cron: '30 9 * * *'
+  schedule:
+    - cron: '30 1,16 * * *'
 
   repository_dispatch:
     types: [check_plugin]
 
+  push:
+    branches: [opendistro-infra-issue-88-3]
+
+env:
+  CHIME_MESSAGE: check_availability pipeline errors
+
 jobs:
   plugin-avilability:
-    name: Check Plugin All Availability
+    name: Check Plugin Availability
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -20,16 +26,47 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Checking Availability
+        env:
+          PLUGIN_TYPES: undefined
+          ODFE_VERSION: undefined
         run: |
           #!/bin/bash
-          CURRENT_NO_PLUGINS="8 10 10"
+          ES_NO_PLUGINS="8"
+          KIBANA_NO_PLUGINS="5"
           CURRENT_DIR=`pwd`
           S3_URL_base="s3://artifacts.opendistroforelasticsearch.amazon.com/downloads"
           S3_URL_zip="${S3_URL_base}/elasticsearch-plugins"
           S3_URL_rpm="${S3_URL_base}/rpms"
           S3_URL_deb="${S3_URL_base}/debs"
-          PLUGIN_TYPES="zip rpm deb"
+          S3_URL_kibana="${S3_URL_base}/kibana-plugins"
+          TSCRIPT_NEWLINE="%0D%0A"
+          RUN_STATUS=0 # 0 is success, 1 is failure
+
+          # Allow user assignment
+          echo "#######################################"
+          echo "PLUGIN_TYPES is: $PLUGIN_TYPES"
+          if [[ $PLUGIN_TYPES == "undefined" ]]
+          then
+            # Kibana currently have the same plugins for all distros
+            PLUGIN_TYPES="zip rpm deb kibana"
+            echo "Use default PLUGIN_TYPES: $PLUGIN_TYPES"
+          fi
           PLUGIN_TYPES=`echo $PLUGIN_TYPES | tr '[:upper:]' '[:lower:]'`
+          echo "#######################################"
+
+          # Allow user assignment
+          echo "ODFE_VERSION is: $ODFE_VERSION"
+
+          if [[ $ODFE_VERSION == "undefined" ]]
+          then
+            cd $CURRENT_DIR/elasticsearch/bin
+            ls -lrt
+            ODFE_VERSION=`./version-info --od`
+            ./version-info --od
+            echo "Use default ODFE_VERSION: $ODFE_VERSION"
+          fi
+          echo "#######################################"
+
 
           PLUGINS_zip="opendistro-alerting/opendistro_alerting \
                        opendistro-anomaly-detection/opendistro-anomaly-detection \
@@ -42,25 +79,27 @@ jobs:
 
           PLUGINS_rpm="opendistro-alerting/opendistro-alerting \
                        opendistro-anomaly-detection/opendistro-anomaly-detector \
-                       opendistro-elasticsearch/opendistroforelasticsearch \
                        opendistro-index-management/opendistro-index-management \
                        opendistro-job-scheduler/opendistro-job-scheduler \
                        opendistro-knn/opendistro-knn \
                        opendistro-performance-analyzer/opendistro-performance-analyzer \
                        opendistro-security/opendistro-security \
-                       opendistro-sql/opendistro-sql \
-                       opendistroforelasticsearch-kibana/opendistroforelasticsearch-kibana"
+                       opendistro-sql/opendistro-sql"
 
           PLUGINS_deb="opendistro-alerting/opendistro-alerting \
                        opendistro-anomaly-detection/opendistro-anomaly-detector \
-                       opendistro-elasticsearch/opendistroforelasticsearch \
                        opendistro-index-management/opendistro-index-management \
                        opendistro-job-scheduler/opendistro-job-scheduler \
                        opendistro-knn/opendistro-knn \
                        opendistro-performance-analyzer/opendistro-performance-analyzer \
                        opendistro-security/opendistro-security \
-                       opendistro-sql/opendistro-sql \
-                       opendistroforelasticsearch-kibana/opendistroforelasticsearch-kibana"
+                       opendistro-sql/opendistro-sql"
+
+          PLUGINS_kibana="opendistro-alerting/opendistro-alerting \
+                       opendistro-anomaly-detection/opendistro-anomaly-detector \
+                       opendistro-index-management/opendistro-index-management \
+                       opendistro-security/opendistro-security \
+                       opendistro-sql-kibana/opendistro-sql-kibana"
 
           # plugin_type
           for plugin_type in $PLUGIN_TYPES
@@ -78,13 +117,6 @@ jobs:
             echo $S3_URL
             echo $PLUGINS | tr " " "\n"
             echo "#######################################"
-  
-            cd $CURRENT_DIR/elasticsearch/bin
-            ls -ltr
-            echo "#######################################"
-            OD_VERSION=`./version-info --od`
-            echo "OD version: $OD_VERSION"
-            echo "#######################################"
             cd /home/runner/work/opendistro-build
             rm -rf plugins
             mkdir -p plugins
@@ -97,7 +129,12 @@ jobs:
               plugin_folder=`echo $item|awk -F/ '{print $1}'`
               plugin_item=`echo $item|awk -F/ '{print $2}'`
               plugin_arr+=( $plugin_item )
-              plugin_artifact="${plugin_item}[_-]${OD_VERSION}.*${plugin_type}"
+              if [[ $plugin_type == "kibana" ]]
+              then
+                plugin_artifact="${plugin_item}[_-]${ODFE_VERSION}.zip"
+              else
+                plugin_artifact="${plugin_item}[_-]${ODFE_VERSION}.*${plugin_type}"
+              fi
               aws s3 cp "${S3_URL}/${plugin_folder}/" . --recursive --exclude "*" --include "${plugin_artifact}" --quiet
             done
             echo "#######################################"
@@ -122,36 +159,61 @@ jobs:
   
             cd /home/runner/work/opendistro-build/opendistro-build/
   
-            echo "<h1><u>ES Plugins ($OD_VERSION) Availability Checks for ($plugin_type)</u></h1>" >> message.md
+            echo "<h1><u>ES Plugins ($ODFE_VERSION) Availability Checks for ($plugin_type)</u></h1>" >> message.md
+            echo "ES Plugins ($ODFE_VERSION) Availability Checks for ($plugin_type): $TSCRIPT_NEWLINE" >> chime_message.md
             
-            echo "<h2>Below plugins are <b>not available</b> for ODFE-$OD_VERSION build</h2>" >> message.md
+            echo "<h2><p style='color:red;'>Below plugins are <b>NOT available</b> for ODFE-$ODFE_VERSION build:</p></h2>" >> message.md
             if [ ${#unavailable_plugin[*]} -gt 0 ]
             then
+                RUN_STATUS=1
                 echo "<ol>" >> message.md
                 for item in ${unavailable_plugin[*]}
                 do
                   echo "<li><h3>$item</h3></li>" >> message.md
+                  echo ":x: $item $TSCRIPT_NEWLINE" >> chime_message.md
                 done
                 echo "</ol>" >> message.md
                 echo "<br><br>" >> message.md
             fi
             
-            echo "<h2>Below plugins are <b>available</b> for ODFE-$OD_VERSION build</h2>" >> message.md
+            echo "<h2><p style='color:green;'>Below plugins are <b>available</b> for ODFE-$ODFE_VERSION build:</p></h2>" >> message.md
             if [ ${#available_plugin[*]} -gt 0 ]
             then
                 echo "<ol>" >> message.md
                 for item in ${available_plugin[*]}
                 do
                   echo "<li><h3>$item</h3></li>" >> message.md
+                  echo ":white_check_mark: $item $TSCRIPT_NEWLINE" >> chime_message.md
                 done
                 echo "</ol>" >> message.md
                 echo "<br><br>" >> message.md
             fi
+            
+            echo "<br><br>" >> message.md
+            echo "$TSCRIPT_NEWLINE" >> chime_message.md
 
           # plugin_type
           done
 
+          echo ::set-env name=CHIME_MESSAGE::$(cat chime_message.md)
+
+          # Use status to decide a success or failure run
+          if [ $RUN_STATUS == 1 ]
+          then
+            echo "You have one or more plugins not available. Exit 1"
+            exit 1
+          fi
+
+      - name: Send Chime Message
+        if: ${{ always() }}
+        uses: ros-tooling/action-amazon-chime@master
+        with:
+          message: ${{ env.CHIME_MESSAGE }} 
+          #webhook: ${{ secrets.CHIME_ODFE_RELEASE }}
+          webhook: ${{ secrets.CHIME_TEST_MESSAGE }}
+
       - name: Send mail
+        if: ${{ always() }}
         uses: dawidd6/action-send-mail@master
         with:
           server_address: smtp.gmail.com
@@ -161,7 +223,8 @@ jobs:
           subject: Opendistro for Elasticsearch Build - Daily Run (Plugin Status)
           # Read file contents as body:
           body: file://message.md
-          to: sngri@amazon.com,odfe-distribution-build@amazon.com
+          #to: sngri@amazon.com,odfe-distribution-build@amazon.com
+          to: zhujiaxi@amazon.com
           from: Opendistro Elasticsearch
           # Optional content type:
           content_type: text/html

--- a/.github/workflows/check_plugin.yml
+++ b/.github/workflows/check_plugin.yml
@@ -42,7 +42,7 @@ jobs:
           # Allow user assignment
           echo "#######################################"
           echo "PLUGIN_TYPES is: $PLUGIN_TYPES"
-          if [[ $PLUGIN_TYPES == "undefined" ]]
+          if [ $PLUGIN_TYPES = "undefined" ]
           then
             # Kibana currently have the same plugins for all distros
             PLUGIN_TYPES="zip rpm deb kibana"
@@ -54,7 +54,7 @@ jobs:
           # Allow user assignment
           echo "ODFE_VERSION is: $ODFE_VERSION"
 
-          if [[ $ODFE_VERSION == "undefined" ]]
+          if [ $ODFE_VERSION = "undefined" ]
           then
             cd $CURRENT_DIR/elasticsearch/bin
             ls -lrt
@@ -126,7 +126,7 @@ jobs:
               plugin_folder=`echo $item|awk -F/ '{print $1}'`
               plugin_item=`echo $item|awk -F/ '{print $2}'`
               plugin_arr+=( $plugin_item )
-              if [ $plugin_type == "kibana" ]
+              if [ $plugin_type = "kibana" ]
               then
                 plugin_artifact="${plugin_item}[_-]${ODFE_VERSION}.*zip"
               else
@@ -156,7 +156,7 @@ jobs:
   
             cd /home/runner/work/opendistro-build/opendistro-build/
   
-              if [ $plugin_type == "kibana" ]
+              if [ $plugin_type = "kibana" ]
               then
                 echo "<h1><u>[KIBANA] Plugins ($ODFE_VERSION) Availability Checks for ( $plugin_type $tot_plugins/${#plugin_arr[*]} )</u></h1>" >> message.md
                 echo ":bar_chart: [KIBANA] Plugins ($ODFE_VERSION) for ( $plugin_type $tot_plugins/${#plugin_arr[*]} ): $TSCRIPT_NEWLINE" >> chime_message.md
@@ -201,7 +201,7 @@ jobs:
           echo ::set-env name=CHIME_MESSAGE::$(cat chime_message.md)
 
           # Use status to decide a success or failure run
-          if [ $RUN_STATUS == 1 ]
+          if [ $RUN_STATUS -eq 1 ]
           then
             echo "You have one or more plugins not available. Exit 1"
             exit 1

--- a/.github/workflows/check_plugin.yml
+++ b/.github/workflows/check_plugin.yml
@@ -7,11 +7,8 @@ on:
   repository_dispatch:
     types: [check_plugin]
 
-  push:
-    branches: [opendistro-infra-issue-88-3]
-
 env:
-  CHIME_MESSAGE: check_availability pipeline errors
+  CHIME_MESSAGE: check_plugin pipeline errors
 
 jobs:
   plugin-avilability:
@@ -96,10 +93,10 @@ jobs:
                        opendistro-sql/opendistro-sql"
 
           PLUGINS_kibana="opendistro-alerting/opendistro-alerting \
-                       opendistro-anomaly-detection/opendistro-anomaly-detector \
-                       opendistro-index-management/opendistro-index-management \
-                       opendistro-security/opendistro-security \
-                       opendistro-sql-kibana/opendistro-sql-kibana"
+                       opendistro-anomaly-detection/opendistro-anomaly-detection-kibana \
+                       opendistro-index-management/opendistro_index_management_kibana \
+                       opendistro-security/opendistro_security_kibana_plugin \
+                       opendistro-sql-kibana/sql-kibana"
 
           # plugin_type
           for plugin_type in $PLUGIN_TYPES
@@ -131,7 +128,7 @@ jobs:
               plugin_arr+=( $plugin_item )
               if [[ $plugin_type == "kibana" ]]
               then
-                plugin_artifact="${plugin_item}[_-]${ODFE_VERSION}.zip"
+                plugin_artifact="${plugin_item}[_-]${ODFE_VERSION}.*zip"
               else
                 plugin_artifact="${plugin_item}[_-]${ODFE_VERSION}.*${plugin_type}"
               fi
@@ -159,8 +156,14 @@ jobs:
   
             cd /home/runner/work/opendistro-build/opendistro-build/
   
-            echo "<h1><u>ES Plugins ($ODFE_VERSION) Availability Checks for ($plugin_type)</u></h1>" >> message.md
-            echo "ES Plugins ($ODFE_VERSION) Availability Checks for ($plugin_type): $TSCRIPT_NEWLINE" >> chime_message.md
+              if [[ $plugin_type == "kibana" ]]
+              then
+                echo "<h1><u>[KIBANA] Plugins ($ODFE_VERSION) Availability Checks for ( $plugin_type $tot_plugins/${#plugin_arr[*]} )</u></h1>" >> message.md
+                echo "[KIBANA] :bar_chart: Plugins ($ODFE_VERSION) for ( $plugin_type $tot_plugins/${#plugin_arr[*]} ): $TSCRIPT_NEWLINE" >> chime_message.md
+              else
+                echo "<h1><u>[ES] Plugins ($ODFE_VERSION) Availability Checks for ( $plugin_type $tot_plugins/${#plugin_arr[*]} )</u></h1>" >> message.md
+                echo "[ES] :mag_right: Plugins ($ODFE_VERSION) for ( $plugin_type $tot_plugins/${#plugin_arr[*]} ): $TSCRIPT_NEWLINE" >> chime_message.md
+              fi
             
             echo "<h2><p style='color:red;'>Below plugins are <b>NOT available</b> for ODFE-$ODFE_VERSION build:</p></h2>" >> message.md
             if [ ${#unavailable_plugin[*]} -gt 0 ]
@@ -209,8 +212,7 @@ jobs:
         uses: ros-tooling/action-amazon-chime@master
         with:
           message: ${{ env.CHIME_MESSAGE }} 
-          #webhook: ${{ secrets.CHIME_ODFE_RELEASE }}
-          webhook: ${{ secrets.CHIME_TEST_MESSAGE }}
+          webhook: ${{ secrets.CHIME_ODFE_RELEASE }}
 
       - name: Send mail
         if: ${{ always() }}
@@ -223,8 +225,7 @@ jobs:
           subject: Opendistro for Elasticsearch Build - Daily Run (Plugin Status)
           # Read file contents as body:
           body: file://message.md
-          #to: sngri@amazon.com,odfe-distribution-build@amazon.com
-          to: zhujiaxi@amazon.com
+          to: sngri@amazon.com,odfe-distribution-build@amazon.com
           from: Opendistro Elasticsearch
           # Optional content type:
           content_type: text/html

--- a/.github/workflows/check_plugin.yml
+++ b/.github/workflows/check_plugin.yml
@@ -126,7 +126,7 @@ jobs:
               plugin_folder=`echo $item|awk -F/ '{print $1}'`
               plugin_item=`echo $item|awk -F/ '{print $2}'`
               plugin_arr+=( $plugin_item )
-              if [[ $plugin_type == "kibana" ]]
+              if [ $plugin_type == "kibana" ]
               then
                 plugin_artifact="${plugin_item}[_-]${ODFE_VERSION}.*zip"
               else
@@ -156,13 +156,13 @@ jobs:
   
             cd /home/runner/work/opendistro-build/opendistro-build/
   
-              if [[ $plugin_type == "kibana" ]]
+              if [ $plugin_type == "kibana" ]
               then
                 echo "<h1><u>[KIBANA] Plugins ($ODFE_VERSION) Availability Checks for ( $plugin_type $tot_plugins/${#plugin_arr[*]} )</u></h1>" >> message.md
-                echo "[KIBANA] :bar_chart: Plugins ($ODFE_VERSION) for ( $plugin_type $tot_plugins/${#plugin_arr[*]} ): $TSCRIPT_NEWLINE" >> chime_message.md
+                echo ":bar_chart: [KIBANA] Plugins ($ODFE_VERSION) for ( $plugin_type $tot_plugins/${#plugin_arr[*]} ): $TSCRIPT_NEWLINE" >> chime_message.md
               else
                 echo "<h1><u>[ES] Plugins ($ODFE_VERSION) Availability Checks for ( $plugin_type $tot_plugins/${#plugin_arr[*]} )</u></h1>" >> message.md
-                echo "[ES] :mag_right: Plugins ($ODFE_VERSION) for ( $plugin_type $tot_plugins/${#plugin_arr[*]} ): $TSCRIPT_NEWLINE" >> chime_message.md
+                echo ":mag_right: [ES] Plugins ($ODFE_VERSION) for ( $plugin_type $tot_plugins/${#plugin_arr[*]} ): $TSCRIPT_NEWLINE" >> chime_message.md
               fi
             
             echo "<h2><p style='color:red;'>Below plugins are <b>NOT available</b> for ODFE-$ODFE_VERSION build:</p></h2>" >> message.md


### PR DESCRIPTION
This PR is to tweak check_plugin.yml so that it can switch targets based on user defined env var PLUGIN_TYPES. It is required for the next improved step of check within build scripts to work.

It can now properly detect the status of a plugin check. If all the necessary plugins are available, return success; else, return failure. The email will still be sent to corresponding teams.

1.7.0 success case:
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/108636259

1.8.0 failure case:
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/108631070

Chime Message case:
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/108759663

![image](https://user-images.githubusercontent.com/65193828/82358575-b2cb3600-99d4-11ea-8451-c577c4b11993.png)


The test will show as failure, which is expected, as currently 1.8.0 plugins are not out yet.
Please use the tests above as part of verification.

Thanks.

------

I open this PR so that commits number are reduced here.
Previous closed PR: #160 