### PR TITLE
Improve deb build script to call check_plugin workflow with results

### DIFF
--- a/.github/workflows/check_plugin_temp.yml
+++ b/.github/workflows/check_plugin_temp.yml
@@ -15,6 +15,17 @@ env:
   EMAIL_ALERT: ${{ github.event.client_payload.EMAIL_ALERT_PL }}
 
 jobs:
+  block-concurrent-runs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Block Concurrent Runs
+        uses: softprops/turnstyle@v1
+        with:
+          poll-interval-seconds: 20
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   plugin-availability-main:
     name: Check Plugin Availability Main
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build-deb-temp.yml
+++ b/.github/workflows/test-build-deb-temp.yml
@@ -5,7 +5,7 @@ on:
 #    - cron: '0 10 * * *'
 
   repository_dispatch:
-    types: [build-deb]
+    types: [build-deb-temp]
 
 jobs:
   plugin-availability:

--- a/.github/workflows/test-build-deb-temp.yml
+++ b/.github/workflows/test-build-deb-temp.yml
@@ -1,0 +1,425 @@
+name: Process Debian Artifacts
+
+on: 
+#  schedule:
+#    - cron: '0 10 * * *'
+
+  repository_dispatch:
+    types: [build-deb]
+
+  push:
+    branches: [opendistro-infra-issue-88-4]
+
+jobs:
+  plugin-availability:
+    name: Check Plugin Availability
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Send Dispatch Event for check_plugin Workflow
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.GitHub_PAT }}
+          event-type: check_plugin_temp # Require Changes
+          client-payload: '{"PLUGIN_TYPES_PL": "deb kibana", "ODFE_VERSION_PL": "", "CHIME_ALERT_PL": "true", "EMAIL_ALERT_PL": "true"}'
+
+      - name: Sleep and wait for check_plugin to trigger
+        uses: juliangruber/sleep-action@v1
+        with:
+          time: 20s
+
+      - name: Wait for check_plugin Workflow Status Return
+        uses: lewagon/wait-on-check-action@master
+        id: wait-for-check_plugin
+        with:
+          repo-token: ${{ secrets.GitHub_PAT }}
+          checki-name: Check Plugin Availability Main # Require Changes
+          wait-interval: 10
+          ref: master
+
+      - name: check_plugin Success
+        if: ${{ success() }}
+        run: echo "Plugin Checks Success"
+
+      - name: check_plugin Failure
+        if: ${{ failure() }}
+        run: echo "Plugin Checks Failure" && exit 1
+
+#  build-es-artifacts:
+#    needs: [plugin-avilability]
+#    name: Build ES Artifacts
+#    runs-on: ubuntu-latest
+#    container:
+#      image: opendistroforelasticsearch/multijava08101112-git:v1
+#    steps:
+#      - uses: actions/checkout@v1
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          aws-region: us-east-1
+#      - name: Build deb
+#        run: |
+#          #!/bin/bash -x
+#          set -e
+#          set -u
+#          export JAVA_HOME=/openjdk12
+#          export PATH=$JAVA_HOME:$PATH
+#          cd elasticsearch/linux_distributions
+#          ./gradlew buildDeb --console=plain -Dbuild.snapshot=false -b ./build.gradle
+#          ls -ltr build/distributions/*.deb
+#          deb_artifact=`ls build/distributions/*.deb`
+#
+#          aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-elasticsearch/
+#          aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"
+#          echo "DEB creation for ES completed"
+#
+#  build-kibana-artifacts:
+#    needs: [plugin-avilability]
+#    name: Build Kibana Artifacts
+#    runs-on: [ubuntu-latest]
+#    container:
+#      image: opendistroforelasticsearch/jsenv:v1
+#    steps:
+#      - uses: actions/checkout@v1
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          aws-region: us-east-1
+#      - name: Build Kibana deb
+#        run: |
+#          #!/bin/bash -x
+#          cd kibana/linux_distributions
+#          sh generate-pkg.sh
+#          deb_artifact=`ls target/*.deb`
+#          ls -ltr target/
+#          tar_checksum_artifact=`ls target/*.tar.gz.sha512`
+#          aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistroforelasticsearch-kibana/
+#
+#  sign-deb-artifacts:
+#    needs: [build-es-artifacts, build-kibana-artifacts]
+#    runs-on: [ubuntu-latest]
+#    container:
+#      image: opendistroforelasticsearch/base-ubuntu
+#    steps:
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          aws-region: us-east-1
+#      - name: Sign Deb Artifacts
+#        env:
+#          passphrase: ${{ secrets.PASSPHRASE }}
+#        run: |
+#
+#          echo "deb http://repo.aptly.info/ squeeze main" | sudo tee -a /etc/apt/sources.list.d/aptly.list
+#          sudo apt-get install -y gnupg1
+#          sudo apt install -y gpgv1
+#          alias gpg=gpg1
+#          wget -qO - https://www.aptly.info/pubkey.txt | sudo apt-key add -
+#
+#          sudo apt-get update -y
+#          sudo apt-get install -y aptly
+#          aws s3 cp s3://opendistro-docs/github-actions/pgp-public-key .
+#          aws s3 cp s3://opendistro-docs/github-actions/pgp-private-key .
+#
+#          aptly repo create -distribution=stable -component=main odfe-release
+#
+#          mkdir -p downloads/debs
+#          aws s3 sync s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs downloads/debs
+#          aptly repo add odfe-release downloads
+#
+#          aptly repo show -with-packages odfe-release
+#          aptly snapshot create opendistroforelasticsearch from repo odfe-release
+#          aptly snapshot list
+#
+#          gpg --import pgp-public-key
+#          gpg --allow-secret-key-import --import pgp-private-key
+#          echo "Printing Secret List"
+#          ls -ltr ~/.gnupg/
+#          gpg --list-secret
+#
+#          aptly publish snapshot -batch=true -passphrase=$passphrase opendistroforelasticsearch
+#
+#          aws s3 sync ~/.aptly/public/ s3://artifacts.opendistroforelasticsearch.amazon.com/staging/apt
+#
+#          aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/staging/apt/*"
+#          
+#  Build-ES-and-Kibana-Ubuntu-Docker:
+#    needs: [sign-deb-artifacts]
+#    runs-on: [ubuntu-latest]
+#    name: Build ubuntu image for Sanity Testing
+#    steps:
+#      - uses: actions/checkout@v1
+#      - name: Checkout Opendistro-Infra
+#        uses: actions/checkout@v1
+#        with:
+#          repository: opendistro-for-elasticsearch/opendistro-infra
+#          ref: jenkins-test
+#          token: ${{ secrets.READ_TOKEN }}
+#      - name: Build Ubuntu Docker Image
+#        env:
+#          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+#          DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+#        run: |
+#          cd elasticsearch/linux_distributions
+#          ES_VER=`../bin/version-info --es`
+#          ODFE_VER=`../bin/version-info --od`
+#          cd ../../..
+#          cd opendistro-infra/scripts/dockerfiles/tests/elasticsearch
+#          docker build --build-arg VER=$ES_VER -t opendistroforelasticsearch/elasticsearch-test-ubuntu:$ODFE_VER -f opendistro.elasticsearch.test.ubuntu.Dockerfile .
+#          
+#          cd ../kibana
+#          docker build -t opendistroforelasticsearch/kibana-test-ubuntu:$ODFE_VER -f opendistro.kibana.test.ubuntu.Dockerfile .
+#          
+#          echo "******************************"
+#          echo "Login to Docker"
+#          echo "******************************"
+#          docker login --username $DOCKER_USER --password $DOCKER_PASS
+#          
+#          docker push opendistroforelasticsearch/elasticsearch-test-ubuntu:$ODFE_VER
+#          sleep 5
+#          docker push opendistroforelasticsearch/kibana-test-ubuntu:$ODFE_VER
+#          
+#      - name: Create Email Message
+#        run: |
+#          echo "<h2>Docker Images for Ubuntu Are Ready</h2>" >> Message.md
+#          echo "<h3> ES Image for Ubuntu Testing: opendistroforelasticsearch/elasticsearch-test-ubuntu:Version-Tag </h3>" >> Message.md
+#          echo "<h3> Kibana Image for Ubuntu Testing: opendistroforelasticsearch/kibana-test-ubuntu:Version-Tag </h3>" >> Message.md
+#          
+#      - name: Send Mail
+#        uses: dawidd6/action-send-mail@master
+#        with:
+#          server_address: smtp.gmail.com
+#          server_port: 465
+#          username: ${{secrets.MAIL_USERNAME}}
+#          password: ${{secrets.MAIL_PASSWORD}}
+#          subject: Opendistro for Elasticsearch Build - Debian Images For Testing
+#          # Read file contents as body:
+#          body: file://Message.md
+#          to: sngri@amazon.com,odfe-distribution-build@amazon.com
+#          from: Opendistro Elasticsearch
+#          # Optional content type:
+#          content_type: text/html
+#          
+#  Test-ISM-Plugin:
+#    needs: [sign-deb-artifacts]
+#    runs-on: [ubuntu-16.04]
+#    strategy:
+#      matrix:
+#        java: [13]
+#    steps:
+#      - uses: actions/checkout@v1
+#      - uses: actions/checkout@v1
+#        with:
+#          repository: opendistro-for-elasticsearch/index-management
+#          ref: master
+#      - name: Setup Java
+#        uses: actions/setup-java@v1
+#        with:
+#          java-version: ${{ matrix.java }}
+#      - name: Run Debian Staging Distrubution
+#        run: |
+#          cd elasticsearch/linux_distributions
+#          es_version=`../bin/version-info --es`
+#          echo $es_version
+#          cd ../../..
+#          sleep 20
+#          sudo sysctl -w vm.max_map_count=262144
+#
+#          sudo add-apt-repository -y ppa:openjdk-r/ppa
+#          sudo apt update -y
+#          sudo apt install -y openjdk-11-jdk
+#          sudo sudo apt install -y net-tools
+#
+#          wget -qO - https://d3g5vo6xdbdb9a.cloudfront.net/GPG-KEY-opendistroforelasticsearch | sudo apt-key add -
+#          echo "deb https://d3g5vo6xdbdb9a.cloudfront.net/staging/apt stable main" | sudo tee -a /etc/apt/sources.list.d/opendistroforelasticsearch.list
+#
+#          wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$es_version-amd64.deb
+#          sudo dpkg -i elasticsearch-oss-$es_version-amd64.deb
+#
+#          sudo apt-get -y update
+#          sudo apt install -y opendistroforelasticsearch
+#          
+#          sudo chmod 777 /etc/elasticsearch/elasticsearch.yml
+#          sudo /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security
+#          sudo sed -i /^opendistro_security/d /etc/elasticsearch/elasticsearch.yml
+#          sudo sed -i /CN=kirk/d /etc/elasticsearch/elasticsearch.yml
+#          sudo sed -i /^node.max_local_storage_nodes/d /etc/elasticsearch/elasticsearch.yml
+#          sudo sed -i /^cluster.routing.allocation.disk.threshold_enabled/d /etc/elasticsearch/elasticsearch.yml
+#
+#          sudo /etc/init.d/elasticsearch start
+#
+#          sleep 30
+#          cd index-management   
+#          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200
+#          
+#
+#  Test-Alerting-Plugin:
+#    needs: [sign-deb-artifacts]
+#    runs-on: [ubuntu-16.04]
+#    strategy:
+#      matrix:
+#        java: [13]
+#    steps:
+#      - uses: actions/checkout@v1
+#      - uses: actions/checkout@v1
+#        with:
+#          repository: opendistro-for-elasticsearch/alerting
+#          ref: master
+#      - name: Setup Java
+#        uses: actions/setup-java@v1
+#        with:
+#          java-version: ${{ matrix.java }}
+#      - name: Run Debian Staging Distrubution
+#        run: |
+#          cd elasticsearch/linux_distributions
+#          es_version=`../bin/version-info --es`
+#          echo $es_version
+#          cd ../../..
+#          sleep 20
+#          sudo sysctl -w vm.max_map_count=262144
+#
+#          sudo add-apt-repository -y ppa:openjdk-r/ppa
+#          sudo apt update -y
+#          sudo apt install -y openjdk-11-jdk
+#          sudo sudo apt install -y net-tools
+#
+#          wget -qO - https://d3g5vo6xdbdb9a.cloudfront.net/GPG-KEY-opendistroforelasticsearch | sudo apt-key add -
+#          echo "deb https://d3g5vo6xdbdb9a.cloudfront.net/staging/apt stable main" | sudo tee -a /etc/apt/sources.list.d/opendistroforelasticsearch.list
+#
+#          wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$es_version-amd64.deb
+#          sudo dpkg -i elasticsearch-oss-$es_version-amd64.deb
+#
+#          sudo apt-get -y update
+#          sudo apt install -y opendistroforelasticsearch
+#          
+#          sudo chmod 777 /etc/elasticsearch/elasticsearch.yml
+#          sudo /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security
+#          sudo sed -i /^opendistro_security/d /etc/elasticsearch/elasticsearch.yml
+#          sudo sed -i /CN=kirk/d /etc/elasticsearch/elasticsearch.yml
+#          sudo sed -i '/http\.port/s/^# *//' /etc/elasticsearch/elasticsearch.yml
+#          sudo sed -i /^node.max_local_storage_nodes/d /etc/elasticsearch/elasticsearch.yml
+#          sudo sed -i /^cluster.routing.allocation.disk.threshold_enabled/d /etc/elasticsearch/elasticsearch.yml
+#
+#          sudo /etc/init.d/elasticsearch start
+#
+#          sleep 30
+#          
+#          cd alerting/alerting
+#          ../gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200
+#          
+#  Test-SQL-Plugin:
+#    needs: [sign-deb-artifacts]
+#    runs-on: [ubuntu-16.04]
+#    strategy:
+#      matrix:
+#        java: [13]
+#    steps:
+#      - uses: actions/checkout@v1
+#      - uses: actions/checkout@v1
+#        with:
+#          repository: opendistro-for-elasticsearch/sql
+#          ref: master
+#      - name: Setup Java
+#        uses: actions/setup-java@v1
+#        with:
+#          java-version: ${{ matrix.java }}
+#      - name: Run Debian Staging Distrubution
+#        run: |
+#          cd elasticsearch/linux_distributions
+#          es_version=`../bin/version-info --es`
+#          echo $es_version
+#          cd ../../..
+#          sleep 20
+#          sudo sysctl -w vm.max_map_count=262144
+#
+#          sudo add-apt-repository -y ppa:openjdk-r/ppa
+#          sudo apt update -y
+#          sudo apt install -y openjdk-11-jdk
+#          sudo sudo apt install -y net-tools
+#
+#          wget -qO - https://d3g5vo6xdbdb9a.cloudfront.net/GPG-KEY-opendistroforelasticsearch | sudo apt-key add -
+#          echo "deb https://d3g5vo6xdbdb9a.cloudfront.net/staging/apt stable main" | sudo tee -a /etc/apt/sources.list.d/opendistroforelasticsearch.list
+#
+#          wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$es_version-amd64.deb
+#          sudo dpkg -i elasticsearch-oss-$es_version-amd64.deb
+#
+#          sudo apt-get -y update
+#          sudo apt install -y opendistroforelasticsearch
+#          
+#          sudo chmod 777 /etc/elasticsearch/elasticsearch.yml
+#          sudo /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security
+#          sudo sed -i /^opendistro_security/d /etc/elasticsearch/elasticsearch.yml
+#          sudo sed -i /CN=kirk/d /etc/elasticsearch/elasticsearch.yml
+#          sudo sed -i /^node.max_local_storage_nodes/d /etc/elasticsearch/elasticsearch.yml
+#          sudo sed -i /^cluster.routing.allocation.disk.threshold_enabled/d /etc/elasticsearch/elasticsearch.yml
+#
+#          sudo /etc/init.d/elasticsearch start
+#
+#          sleep 30
+#          cd sql
+#          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200
+#          
+#  Test-KNN-Plugin:
+#    needs: [sign-deb-artifacts]
+#    runs-on: [ubuntu-16.04]
+#    strategy:
+#      matrix:
+#        java: [13]
+#    steps:
+#      - uses: actions/checkout@v1
+#      - uses: actions/checkout@v1
+#        with:
+#          repository: opendistro-for-elasticsearch/k-NN
+#          ref: master
+#      - name: Setup Java
+#        uses: actions/setup-java@v1
+#        with:
+#          java-version: ${{ matrix.java }}
+#      - name: Run Debian Staging Distrubution
+#        run: |
+#          cd elasticsearch/linux_distributions
+#          es_version=`../bin/version-info --es`
+#          echo $es_version
+#          cd ../../..
+#          sleep 20
+#          sudo sysctl -w vm.max_map_count=262144
+#
+#          sudo add-apt-repository -y ppa:openjdk-r/ppa
+#          sudo apt update -y
+#          sudo apt install -y openjdk-11-jdk
+#          sudo sudo apt install -y net-tools
+#
+#          wget -qO - https://d3g5vo6xdbdb9a.cloudfront.net/GPG-KEY-opendistroforelasticsearch | sudo apt-key add -
+#          echo "deb https://d3g5vo6xdbdb9a.cloudfront.net/staging/apt stable main" | sudo tee -a /etc/apt/sources.list.d/opendistroforelasticsearch.list
+#
+#          wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$es_version-amd64.deb
+#          sudo dpkg -i elasticsearch-oss-$es_version-amd64.deb
+#
+#          sudo apt-get -y update
+#          sudo apt install -y opendistroforelasticsearch
+#          
+#          sudo chmod 777 /etc/elasticsearch/elasticsearch.yml
+#          sudo /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security
+#          sudo sed -i /^opendistro_security/d /etc/elasticsearch/elasticsearch.yml
+#          sudo sed -i /CN=kirk/d /etc/elasticsearch/elasticsearch.yml
+#          sudo sed -i /^node.max_local_storage_nodes/d /etc/elasticsearch/elasticsearch.yml
+#          sudo sed -i /^cluster.routing.allocation.disk.threshold_enabled/d /etc/elasticsearch/elasticsearch.yml
+#
+#          sudo /etc/init.d/elasticsearch start
+#
+#          sleep 30
+#          cd k-NN
+#          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200

--- a/.github/workflows/test-build-deb-temp.yml
+++ b/.github/workflows/test-build-deb-temp.yml
@@ -7,9 +7,6 @@ on:
   repository_dispatch:
     types: [build-deb]
 
-  push:
-    branches: [opendistro-infra-issue-88-4]
-
 jobs:
   plugin-availability:
     name: Check Plugin Availability


### PR DESCRIPTION
This PR is to add the dynamic trigger of check_plugin workflow and result verification process into the build script of deb distributions.

The pre-requisite here: check_plugin.yml has already been updated here: #161 #172.

# test-build-deb-temp.yml trigger check_plugin_temp.yml

Yes Alert:
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/112768527
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/112768696

No alert:
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/112767077
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/112767294