### PR TITLE
Opendistro build 1.8.0 ad naming 1

### DIFF
--- a/.github/workflows/check_plugin.yml
+++ b/.github/workflows/check_plugin.yml
@@ -75,7 +75,7 @@ jobs:
                        opendistro-sql/opendistro_sql"
 
           PLUGINS_rpm="opendistro-alerting/opendistro-alerting \
-                       opendistro-anomaly-detection/opendistro-anomaly-detector \
+                       opendistro-anomaly-detection/opendistro-anomaly-detection \
                        opendistro-index-management/opendistro-index-management \
                        opendistro-job-scheduler/opendistro-job-scheduler \
                        opendistro-knn/opendistro-knn \
@@ -84,7 +84,7 @@ jobs:
                        opendistro-sql/opendistro-sql"
 
           PLUGINS_deb="opendistro-alerting/opendistro-alerting \
-                       opendistro-anomaly-detection/opendistro-anomaly-detector \
+                       opendistro-anomaly-detection/opendistro-anomaly-detection \
                        opendistro-index-management/opendistro-index-management \
                        opendistro-job-scheduler/opendistro-job-scheduler \
                        opendistro-knn/opendistro-knn \


### PR DESCRIPTION
This PR is to change the AD plugin with the new naming convention for consistency purposes in 1.8.0 ODFE Version.

https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/110596674