### PR TITLE
Checking out the repos using tags instead of master

### DIFF
--- a/.github/workflows/test-build-deb.yml
+++ b/.github/workflows/test-build-deb.yml
@@ -218,14 +218,24 @@ jobs:
         java: [14]
     steps:
       - uses: actions/checkout@v1
+
+      - name: Getting OD Version
+        run: |
+          cd elasticsearch/bin
+          OD_VERSION=`./version-info --od`
+          plugin_tag=v$OD_VERSION.0
+          echo "::set-env name=tag::$plugin_tag"
+
       - uses: actions/checkout@v1
         with:
           repository: opendistro-for-elasticsearch/index-management
-          ref: master
+          ref: ${{env.tag}}
+
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+          
       - name: Run Debian Staging Distrubution
         run: |
           cd elasticsearch/linux_distributions
@@ -271,14 +281,24 @@ jobs:
         java: [14]
     steps:
       - uses: actions/checkout@v1
+
+      - name: Getting OD Version
+        run: |
+          cd elasticsearch/bin
+          OD_VERSION=`./version-info --od`
+          plugin_tag=v$OD_VERSION.0
+          echo "::set-env name=tag::$plugin_tag"
+
       - uses: actions/checkout@v1
         with:
           repository: opendistro-for-elasticsearch/alerting
-          ref: master
+          ref: ${{env.tag}}
+
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+
       - name: Run Debian Staging Distrubution
         run: |
           cd elasticsearch/linux_distributions
@@ -325,14 +345,23 @@ jobs:
         java: [14]
     steps:
       - uses: actions/checkout@v1
+      - name: Getting OD Version
+        run: |
+          cd elasticsearch/bin
+          OD_VERSION=`./version-info --od`
+          plugin_tag=v$OD_VERSION.0
+          echo "::set-env name=tag::$plugin_tag"
+
       - uses: actions/checkout@v1
         with:
           repository: opendistro-for-elasticsearch/sql
-          ref: master
+          ref: ${{env.tag}}
+
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+
       - name: Run Debian Staging Distrubution
         run: |
           cd elasticsearch/linux_distributions
@@ -377,10 +406,19 @@ jobs:
         java: [14]
     steps:
       - uses: actions/checkout@v1
+
+      - name: Getting OD Version
+        run: |
+          cd elasticsearch/bin
+          OD_VERSION=`./version-info --od`
+          plugin_tag=v$OD_VERSION.0
+          echo "::set-env name=tag::$plugin_tag"
+
       - uses: actions/checkout@v1
         with:
           repository: opendistro-for-elasticsearch/k-NN
-          ref: master
+          ref: ${{env.tag}}
+
       - name: Setup Java
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/test-build-tar.yml
+++ b/.github/workflows/test-build-tar.yml
@@ -119,16 +119,26 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
+
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
       - uses: actions/checkout@v1
+
+      - name: Getting OD Version
+        run: |
+          cd elasticsearch/bin
+          OD_VERSION=`./version-info --od`
+          plugin_tag=v$OD_VERSION.0
+          echo "::set-env name=tag::$plugin_tag"
+
       - name: Checkout ISM
         uses: actions/checkout@v1
         with:
           repository: opendistro-for-elasticsearch/index-management
-          ref: master
+          ref: ${{env.tag}}
+
       - name: Run Tests
         run: |
           cd ..
@@ -167,11 +177,20 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - uses: actions/checkout@v1
-      - name: Checkout ISM
+
+      - name: Getting OD Version
+        run: |
+          cd elasticsearch/bin
+          OD_VERSION=`./version-info --od`
+          plugin_tag=v$OD_VERSION.0
+          echo "::set-env name=tag::$plugin_tag"
+
+      - name: Checkout Alerting 
         uses: actions/checkout@v1
         with:
           repository: opendistro-for-elasticsearch/alerting
-          ref: master
+          ref: ${{env.tag}}
+
       - name: Run Tests
         run: |
           cd ..
@@ -205,16 +224,27 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
+
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+
       - uses: actions/checkout@v1
+
+      - name: Getting OD Version
+        run: |
+          cd elasticsearch/bin
+          OD_VERSION=`./version-info --od`
+          plugin_tag=v$OD_VERSION.0
+          echo "::set-env name=tag::$plugin_tag"
+
       - name: Checkout SQL
         uses: actions/checkout@v1
         with:
           repository: opendistro-for-elasticsearch/sql
-          ref: master
+          ref: ${{env.tag}}
+
       - name: Run Tests
         run: |
           cd ..
@@ -247,16 +277,27 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
+
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+
       - uses: actions/checkout@v1
+
+      - name: Getting OD Version
+        run: |
+          cd elasticsearch/bin
+          OD_VERSION=`./version-info --od`
+          plugin_tag=v$OD_VERSION.0
+          echo "::set-env name=tag::$plugin_tag"
+
       - name: Checkout k-NN
         uses: actions/checkout@v1
         with:
           repository: opendistro-for-elasticsearch/k-NN
-          ref: master
+          ref: ${{env.tag}}
+          
       - name: Run Tests
         run: |
           cd ..

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -60,10 +60,19 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
+
+      - name: Getting OD Version
+        run: |
+          cd elasticsearch/bin
+          OD_VERSION=`./version-info --od`
+          plugin_tag=v$OD_VERSION.0
+          echo "::set-env name=tag::$plugin_tag"
+
       - uses: actions/checkout@v1
         with:
            repository: opendistro-for-elasticsearch/index-management
-           ref: master  
+           ref: ${{env.tag}}
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -115,10 +124,19 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
+
+      - name: Getting OD Version
+        run: |
+          cd elasticsearch/bin
+          OD_VERSION=`./version-info --od`
+          plugin_tag=v$OD_VERSION.0
+          echo "::set-env name=tag::$plugin_tag"
+
       - uses: actions/checkout@v1
         with:
            repository: opendistro-for-elasticsearch/alerting
-           ref: master  
+           ref: ${{env.tag}}  
+           
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
The plugin repositories were using master as the reference branch. This PR replaces it with the version tag (v1.8.0.0 in this case)