### PR TITLE
Added support for podsecuritypolicies. Added the capability SYS_CHROOT.

### DIFF
--- a/helm/opendistro-es/templates/psp.yml
+++ b/helm/opendistro-es/templates/psp.yml
@@ -47,4 +47,6 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+  allowedCapabilities:
+    - 'SYS_CHROOT'
 {{- end }}


### PR DESCRIPTION
See [this issue](https://github.com/opendistro-for-elasticsearch/opendistro-build/issues/228)

Does this PR include tests?

Deployed with 
```
helm install local-opendistro ./opendistro-build/helm/opendistro-es \
>        --set kibana.ingress.enabled=true \
>        --set kibana.ingress.hosts={opendistro.local} \
>        --set elasticsearch.client.ingress.enabled=false \
>        --set kibana.replicas=1 \
>        --set elasticsearch.master.replicas=1 \
>        --set elasticsearch.client.replicas=1 \
>        --set elasticsearch.data.replicas=1 \
>        --set elasticsearch.master.storageClassName="local-default-storage" \
>        --set elasticsearch.master.storage="10Gi" \
>        --set elasticsearch.data.storageClassName="local-default-storage" \
>        --set elasticsearch.data.storage="10Gi" \
>        --set global.psp.create=true
```

No errors, the psp is deployed with the right capability : 
```
kubectl get psp skube-siem-opendistro-es-psp
NAME                           PRIV   CAPS         SELINUX    RUNASUSER   FSGROUP     SUPGROUP    READONLYROOTFS   VOLUMES
local-opendistro-opendistro-es-psp   true   SYS_CHROOT   RunAsAny   RunAsAny    MustRunAs   MustRunAs   false            configMap,emptyDir,projected,secret,downwardAPI,persistentVolumeClaim
```