### PR TITLE
Reduce scripts complexity in check plugins/windows/tar

### DIFF
--- a/.github/scripts/check_plugin.sh
+++ b/.github/scripts/check_plugin.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # This script is meant to be run within .github/scripts folder structure
-ROOT=`git rev-parse --show-toplevel`
+REPO_ROOT=`git rev-parse --show-toplevel`
+ROOT=`dirname $(realpath $0)`; echo $ROOT; cd $ROOT
 S3_BUCKET="artifacts.opendistroforelasticsearch.amazon.com"
 S3_DIR_zip="downloads/elasticsearch-plugins"
 S3_DIR_rpm="downloads/rpms"
@@ -11,9 +12,6 @@ TSCRIPT_NEWLINE="%0D%0A"
 RUN_STATUS=0 # 0 is success, 1 is failure
 PLUGIN_TYPES=$1
 ODFE_VERSION=$2
-
-echo "Running $0"
-echo $ROOT
 
 # This script allows users to manually assign parameters
 if [ "$#" -gt 2 ]
@@ -40,8 +38,7 @@ echo "#######################################"
 echo "ODFE_VERSION is: $ODFE_VERSION"
 if [ -z "$ODFE_VERSION" ]
 then
-  cd $ROOT/elasticsearch/bin
-  ODFE_VERSION=`./version-info --od`
+  ODFE_VERSION=`$REPO_ROOT/bin/version-info --od`
   echo "Use default ODFE_VERSION: $ODFE_VERSION"
 fi
 echo "#######################################"
@@ -190,6 +187,7 @@ cp -v message.md /tmp/message.md
 cp -v chime_message.md /tmp/chime_message.md
 
 # Use status to decide a success or failure run
+# DO NOT change this as workflow email is depend on this
 if [ "$RUN_STATUS" -eq 1 ]
 then
   echo "Plugin Checks Failure with 1 or more plugin(s) is not available"

--- a/.github/workflows/check_plugin.yml
+++ b/.github/workflows/check_plugin.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Checking Availability
         run: |
           #!/bin/bash
+          set -e
           .github/scripts/check_plugin.sh
           echo ::set-env name=CHIME_MESSAGE::$(cat /tmp/chime_message.md)
           exit `cat /tmp/plugin_status.check`

--- a/.github/workflows/check_plugin_old.yml
+++ b/.github/workflows/check_plugin_old.yml
@@ -67,10 +67,7 @@ jobs:
           echo "ODFE_VERSION is: $ODFE_VERSION"
           if [ -z "$ODFE_VERSION" ]
           then
-            cd $CURRENT_DIR/elasticsearch/bin
-            ls -lrt
-            ODFE_VERSION=`./version-info --od`
-            ./version-info --od
+            ODFE_VERSION=`./bin/version-info --od`
             echo "Use default ODFE_VERSION: $ODFE_VERSION"
           fi
           echo "#######################################"

--- a/.github/workflows/release-sync-tar.yml
+++ b/.github/workflows/release-sync-tar.yml
@@ -19,8 +19,7 @@ jobs:
 
       - name: Getting OD version
         run: |
-          cd elasticsearch/bin
-          OD_VERSION=`./version-info --od`
+          OD_VERSION=`./bin/version-info --od`
           echo "::set-env name=od_version::$OD_VERSION"
     
       - name: Moving tar artifacts from staging to prod

--- a/.github/workflows/release-sync-windows.yml
+++ b/.github/workflows/release-sync-windows.yml
@@ -19,8 +19,7 @@ jobs:
 
       - name: Getting OD version
         run: |
-          cd elasticsearch/bin
-          OD_VERSION=`./version-info --od`
+          OD_VERSION=`./bin/version-info --od`
           echo "::set-env name=od_version::$OD_VERSION"
     
       - name: Moving windows artifacts from staging to prod

--- a/.github/workflows/test-build-deb.yml
+++ b/.github/workflows/test-build-deb.yml
@@ -73,7 +73,7 @@ jobs:
           set -e
           set -u
           cd kibana/linux_distributions
-          ./generate-pkg.sh deb
+          ./opendistro-kibana-build.sh deb
           deb_artifact=`ls target/*.deb`
           ls -ltr target/
           aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistroforelasticsearch-kibana/
@@ -224,10 +224,7 @@ jobs:
           cd ../../..
           sleep 20
           sudo sysctl -w vm.max_map_count=262144
-
-          sudo add-apt-repository -y ppa:openjdk-r/ppa
           sudo apt update -y
-          sudo apt install -y openjdk-11-jdk
           sudo sudo apt install -y net-tools
 
           wget -qO - https://d3g5vo6xdbdb9a.cloudfront.net/GPG-KEY-opendistroforelasticsearch | sudo apt-key add -
@@ -238,9 +235,11 @@ jobs:
 
           sudo apt-get -y update
           sudo apt install -y opendistroforelasticsearch
-          
+          sudo mkdir /home/runner/work/repo
+          sudo chmod 777 /home/runner/work/repo
           sudo chmod 777 /etc/elasticsearch/elasticsearch.yml
           sudo /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security
+          sudo sed -i '/path.logs/a path.repo: ["/home/runner/work/repo"]' /etc/elasticsearch/elasticsearch.yml
           sudo sed -i /^opendistro_security/d /etc/elasticsearch/elasticsearch.yml
           sudo sed -i /CN=kirk/d /etc/elasticsearch/elasticsearch.yml
           sudo sed -i /^node.max_local_storage_nodes/d /etc/elasticsearch/elasticsearch.yml
@@ -364,6 +363,56 @@ jobs:
           sleep 30
           cd sql
           ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest
+          
+  Test-SQL-Plugin-With-Security:
+    needs: [sign-deb-artifacts]
+    runs-on: [ubuntu-16.04]
+    strategy:
+      matrix:
+        java: [14]
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions/checkout@v1
+        with:
+          repository: opendistro-for-elasticsearch/sql
+          ref: ${{needs.sign-deb-artifacts.outputs.tag}}
+
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Run Debian Staging Distrubution
+        run: |
+          cd elasticsearch/linux_distributions
+          es_version=`../bin/version-info --es`
+          echo $es_version
+          cd ../../..
+          sleep 20
+          sudo sysctl -w vm.max_map_count=262144
+
+          sudo add-apt-repository -y ppa:openjdk-r/ppa
+          sudo apt update -y
+          sudo apt install -y openjdk-11-jdk
+          sudo sudo apt install -y net-tools
+
+          wget -qO - https://d3g5vo6xdbdb9a.cloudfront.net/GPG-KEY-opendistroforelasticsearch | sudo apt-key add -
+          echo "deb https://d3g5vo6xdbdb9a.cloudfront.net/staging/apt stable main" | sudo tee -a /etc/apt/sources.list.d/opendistroforelasticsearch.list
+
+          wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$es_version-amd64.deb
+          sudo dpkg -i elasticsearch-oss-$es_version-amd64.deb
+
+          sudo apt-get -y update
+          sudo apt install -y opendistroforelasticsearch
+          
+          sudo chmod 777 /etc/elasticsearch/elasticsearch.yml
+          sudo sed -i /^node.max_local_storage_nodes/d /etc/elasticsearch/elasticsearch.yml
+          sudo /etc/init.d/elasticsearch start
+
+          sleep 30
+          cd sql
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest -Dhttps=true -Duser=admin -Dpassword=admin
           
   Test-KNN-Plugin:
     needs: [sign-deb-artifacts]

--- a/.github/workflows/test-build-rpm.yml
+++ b/.github/workflows/test-build-rpm.yml
@@ -74,7 +74,7 @@ jobs:
           set -e
           set -u
           cd kibana/linux_distributions
-          ./generate-pkg.sh rpm
+          ./opendistro-kibana-build.sh rpm
           rpm_artifact=`ls target/*.rpm`
           ls -ltr target/
           aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistroforelasticsearch-kibana/
@@ -196,8 +196,11 @@ jobs:
           export PATH=$PATH:$JAVA_HOME
           sudo yum install unzip -y
           sudo yum install opendistroforelasticsearch-${{env.od_version}} -y
+          sudo mkdir /home/repo
+          sudo chmod 777 /home/repo
           sudo chmod 777 /etc/elasticsearch/elasticsearch.yml    
-          sudo /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security 
+          sudo /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security
+          sudo sed -i '/path.logs/a path.repo: ["/home/repo"]' /etc/elasticsearch/elasticsearch.yml 
           sudo sed -i /^opendistro_security/d /etc/elasticsearch/elasticsearch.yml
           sudo sed -i /CN=kirk/d /etc/elasticsearch/elasticsearch.yml
           sudo sed -i /^node.max_local_storage_nodes/d /etc/elasticsearch/elasticsearch.yml

--- a/.github/workflows/test-build-tar.yml
+++ b/.github/workflows/test-build-tar.yml
@@ -36,8 +36,7 @@ jobs:
     - name: Getting OD version
       id: version
       run: |
-        cd elasticsearch/bin
-        OD_VERSION=`./version-info --od`
+        OD_VERSION=`./bin/version-info --od`
         plugin_tag=v$OD_VERSION.0
         echo "::set-output name=p_tag::$plugin_tag"
 
@@ -48,22 +47,7 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
     - name: Build tar
-      run: |
-        #!/bin/bash -x
-        set -e
-        set -u
-        export JAVA_HOME=/openjdk12
-        export PATH=$JAVA_HOME:$PATH
-        cd elasticsearch/linux_distributions
-        ./opendistro-tar-build.sh
-        tar_artifact=`ls target/*.tar.gz`
-        ls -ltr target/
-        tar_checksum_artifact=`ls target/*.tar.gz.sha512`
-
-        aws s3 cp $tar_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/tarball/opendistro-elasticsearch/
-        aws s3 cp $tar_checksum_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/tarball/opendistro-elasticsearch/
-        aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"
-        echo "TAR creation for ES completed"
+      run: set -u; export JAVA_HOME=/openjdk12; export PATH=$JAVA_HOME:$PATH; ./elasticsearch/linux_distributions/opendistro-tar-build.sh
 
         
   build-kibana-artifacts:
@@ -81,17 +65,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Build Kibana
-        run: |
-          #!/bin/bash -x
-          set -e
-          set -u
-          cd kibana/linux_distributions 
-          ./generate-pkg.sh tar
-          tar_artifact=`ls target/*.tar.gz`
-          tar_checksum_artifact=`ls target/*.tar.gz.sha512`
-          ls -ltr target/
-          aws s3 cp $tar_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/tarball/opendistroforelasticsearch-kibana/
-          aws s3 cp $tar_checksum_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/tarball/opendistroforelasticsearch-kibana/
+        run: ./kibana/linux_distributions/opendistro-kibana-build.sh tar
           
   Test-ISM-Plugin:
     needs: [build-es-artifacts]
@@ -119,10 +93,10 @@ jobs:
           ref: ${{needs.build-es-artifacts.outputs.tag}}
       - name: Run Tests
         run: |
+          odfe_version=`./bin/version-info --od`
+          echo $odfe_version
           cd ..
           cd opendistro-build/elasticsearch/linux_distributions
-          odfe_version=`../bin/version-info --od`
-          echo $odfe_version
           cd ../../..
           aws s3 cp s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/tarball/opendistro-elasticsearch/opendistroforelasticsearch-$odfe_version.tar.gz .
           tar -zxf opendistroforelasticsearch-$odfe_version.tar.gz
@@ -162,10 +136,10 @@ jobs:
           ref: ${{needs.build-es-artifacts.outputs.tag}}
       - name: Run Tests
         run: |
+          odfe_version=`./bin/version-info --od`
+          echo $odfe_version
           cd ..
           cd opendistro-build/elasticsearch/linux_distributions
-          odfe_version=`../bin/version-info --od`
-          echo $odfe_version
           cd ../../..
           aws s3 cp s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/tarball/opendistro-elasticsearch/opendistroforelasticsearch-$odfe_version.tar.gz .
           tar -zxf opendistroforelasticsearch-$odfe_version.tar.gz
@@ -205,10 +179,10 @@ jobs:
           ref: ${{needs.build-es-artifacts.outputs.tag}}
       - name: Run Tests
         run: |
+          odfe_version=`./bin/version-info --od`
+          echo $odfe_version
           cd ..
           cd opendistro-build/elasticsearch/linux_distributions
-          odfe_version=`../bin/version-info --od`
-          echo $odfe_version
           cd ../../..
           aws s3 cp s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/tarball/opendistro-elasticsearch/opendistroforelasticsearch-$odfe_version.tar.gz .
           tar -zxf opendistroforelasticsearch-$odfe_version.tar.gz
@@ -247,10 +221,10 @@ jobs:
           ref: ${{needs.build-es-artifacts.outputs.tag}}
       - name: Run Tests
         run: |
+          odfe_version=`./bin/version-info --od`
+          echo $odfe_version
           cd ..
           cd opendistro-build/elasticsearch/linux_distributions
-          odfe_version=`../bin/version-info --od`
-          echo $odfe_version
           cd ../../..
           aws s3 cp s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/tarball/opendistro-elasticsearch/opendistroforelasticsearch-$odfe_version.tar.gz .
           tar -zxf opendistroforelasticsearch-$odfe_version.tar.gz

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -17,8 +17,7 @@ jobs:
     - name: Getting OD version
       id: version
       run: |
-        cd elasticsearch/bin
-        OD_VERSION=`./version-info --od`
+        OD_VERSION=`./bin/version-info --od`
         plugin_tag=v$OD_VERSION.0
         echo "::set-output name=p_tag::$plugin_tag"
 
@@ -84,12 +83,10 @@ jobs:
           python -m pip install --upgrade pip
           echo pip3 -version
           pip3 install awscli
-          cd elasticsearch\bin\
           dir
           $PACKAGE="opendistroforelasticsearch"
-          $OD_VERSION=$(python .\version-info --od)
+          $OD_VERSION=$(./bin/version-info --od)
           $S3_PACKAGE="odfe-"+$OD_VERSION+".zip"
-          cd ..\..
           dir
           echo downloading zip from S3 
           aws s3 cp s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/staging/odfe-window-zip/$S3_PACKAGE .\
@@ -138,11 +135,9 @@ jobs:
           python -m pip install --upgrade pip
           echo pip3 -version
           pip3 install awscli
-          cd elasticsearch\bin\
           $PACKAGE="opendistroforelasticsearch"
-          $OD_VERSION=$(python .\version-info --od)
+          $OD_VERSION=$(./bin/version-info --od)
           $S3_PACKAGE="odfe-"+$OD_VERSION+".zip"
-          cd ..\..
           dir
           echo downloading zip from S3 
           aws s3 cp s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/staging/odfe-window-zip/$S3_PACKAGE .\

--- a/elasticsearch/windows/opendistro-windows-build.sh
+++ b/elasticsearch/windows/opendistro-windows-build.sh
@@ -3,8 +3,9 @@ set -e
 
 REPO_ROOT=`git rev-parse --show-toplevel`
 ROOT=`dirname $(realpath $0)`; echo $ROOT; cd $ROOT
-ES_VERSION=`$REPO_ROOT/bin/version-info --es`
-OD_VERSION=`$REPO_ROOT/bin/version-info --od`
+ES_VERSION=`$REPO_ROOT/bin/version-info --es`; echo $ES_VERSION
+OD_VERSION=`$REPO_ROOT/bin/version-info --od`; echo $OD_VERSION
+S3_BUCKET="artifacts.opendistroforelasticsearch.amazon.com"
 ARTIFACTS_URL="https://d3g5vo6xdbdb9a.cloudfront.net"
 PACKAGE_NAME="opendistroforelasticsearch"
 TARGET_DIR="$ROOT/target"
@@ -42,7 +43,7 @@ rm -rf elasticsearch-oss-$ES_VERSION-windows-x86_64.zip
 # Install plugins
 for plugin_path in $PLUGINS
 do
-  plugin_latest=`aws s3api list-objects --bucket artifacts.opendistroforelasticsearch.amazon.com --prefix "downloads/elasticsearch-plugins/${plugin_path}" --query 'Contents[].[Key]' --output text | sort | tail -n 1`
+  plugin_latest=`aws s3api list-objects --bucket $S3_BUCKET --prefix "downloads/elasticsearch-plugins/${plugin_path}" --query 'Contents[].[Key]' --output text | sort | tail -n 1`
   echo "installing $plugin_latest"
   $ROOT/elasticsearch-$ES_VERSION/bin/elasticsearch-plugin install --batch "${ARTIFACTS_URL}/${plugin_latest}"; \
 done
@@ -84,6 +85,6 @@ install4j8.0.4/bin/install4jc -d $TARGET_DIR -D sourcedir=./$PACKAGE_NAME-$OD_VE
 ls -ltr $TARGET_DIR
 
 # Upload top S3
-aws s3 cp $TARGET_DIR/*.exe s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/staging/odfe-executable/
-aws s3 cp $TARGET_DIR/*.zip s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/staging/odfe-window-zip/
+aws s3 cp $TARGET_DIR/*.exe s3://$S3_BUCKET/downloads/odfe-windows/staging/odfe-executable/
+aws s3 cp $TARGET_DIR/*.zip s3://$S3_BUCKET/downloads/odfe-windows/staging/odfe-window-zip/
 aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"

--- a/kibana/README.md
+++ b/kibana/README.md
@@ -94,17 +94,17 @@ cd opendistro-build/kibana/linux_distributions
 
 To build the rpm package
 ```
-./generate-pkg.sh rpm
+./opendistro-kibana-build.sh rpm
 ```
 
 To build the deb package
 ```
-./generate-pkg.sh deb
+./opendistro-kibana-build.sh deb
 ```
 
-To build rpm & deb packages
+To build tar & rpm & deb packages
 ```
-./generate-pkg.sh
+./opendistro-kibana-build.sh
 ```
 
 Download and install Kibana

--- a/kibana/windows/opendistro-windows-kibana-build.sh
+++ b/kibana/windows/opendistro-windows-kibana-build.sh
@@ -3,8 +3,9 @@ set -e
 
 REPO_ROOT=`git rev-parse --show-toplevel`
 ROOT=`dirname $(realpath $0)`; echo $ROOT; cd $ROOT
-ES_VERSION=`$REPO_ROOT/bin/version-info --es`
-OD_VERSION=`$REPO_ROOT/bin/version-info --od`
+ES_VERSION=`$REPO_ROOT/bin/version-info --es`; echo $ES_VERSION
+OD_VERSION=`$REPO_ROOT/bin/version-info --od`; echo $OD_VERSION
+S3_BUCKET="artifacts.opendistroforelasticsearch.amazon.com"
 ARTIFACTS_URL="https://d3g5vo6xdbdb9a.cloudfront.net"
 PACKAGE_NAME="opendistroforelasticsearch-kibana"
 TARGET_DIR="$ROOT/target"
@@ -12,7 +13,7 @@ TARGET_DIR="$ROOT/target"
 mkdir $TARGET_DIR
 
 # Downloading tar from s3
-aws s3 cp "s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/tarball/${PACKAGE_NAME}/${PACKAGE_NAME}-${OD_VERSION}.tar.gz" . --quiet ; echo $0
+aws s3 cp "s3://${S3_BUCKET}/downloads/tarball/${PACKAGE_NAME}/${PACKAGE_NAME}-${OD_VERSION}.tar.gz" . --quiet ; echo $0
 
 # Untar the tar artifact
 tar -xzf $PACKAGE_NAME-$OD_VERSION.tar.gz
@@ -50,6 +51,6 @@ install4j8.0.4/bin/install4jc -d $TARGET_DIR -D sourcedir=./$PACKAGE_NAME,versio
 ls -ltr $TARGET_DIR
 
 # Copy to s3
-aws s3 cp $TARGET_DIR/*.exe s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/staging/odfe-executable/
-aws s3 cp $TARGET_DIR/*.zip s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/staging/odfe-window-zip/
+aws s3 cp $TARGET_DIR/*.exe s3://$S3_BUCKET/downloads/odfe-windows/staging/odfe-executable/
+aws s3 cp $TARGET_DIR/*.zip s3://$S3_BUCKET/downloads/odfe-windows/staging/odfe-window-zip/
 aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"


### PR DESCRIPTION
This PR is to reduce the complexity of the scripts and workflows in check_plugin and windows/tar workflows/scripts.
Also, the name of the script in kibana folder ./generate-pkg.sh has been renamed to ./opendistro-kibana-build.sh for consistent naming convention.

------

### Test Cases:
- check_plugin:
  - success case: 
     https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/125217569
  - failure case: 
     https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/125212578
- windows:
   https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/126417132
- tar:
   https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/126417134

The bin directories in elasticsearch and kibana folder will be removed later, it is kept now until we make changes to all the scripts for backward compatibility.