### PR TITLE
Reduce scripts complexity in deb and rpm workflows

### DIFF
--- a/.github/workflows/release-sync-ami.yml
+++ b/.github/workflows/release-sync-ami.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Getting OD version
         run: |
           cd elasticsearch/bin
-          OD_VERSION=`./version-info --od`
+          OD_VERSION=`./bin/version-info --od`
           echo "::set-env name=od_version::$OD_VERSION"
     
       - name: Set AMI from private to public in all regions

--- a/.github/workflows/test-build-ami.yml
+++ b/.github/workflows/test-build-ami.yml
@@ -24,6 +24,8 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.ODFE_AMI_AWS_SECRET_ACCESS_KEY }}
       run: |
         #!/bin/bash
+        export APT_OSS_version=`./bin/version-info --es`
+        OD_version=`./bin/version-info --od`
         cd elasticsearch/bin
         export region_name="us-east-1"
         export os="amazonLinux"
@@ -47,8 +49,6 @@ jobs:
         fi
 
         export base_image_id=$latest_base_image_id 
-        export APT_OSS_version=`./bin/version-info --es`
-        OD_version=`./bin/version-info --od`
         export RPM_package_version=$OD_version
         export AMI_name="Open Distro for Elasticsearch-$OD_version-`date +"%D-%H.%M.%S"`"
         cd -

--- a/.github/workflows/test-build-ami.yml
+++ b/.github/workflows/test-build-ami.yml
@@ -47,8 +47,8 @@ jobs:
         fi
 
         export base_image_id=$latest_base_image_id 
-        export APT_OSS_version=`./version-info --es`
-        OD_version=`./version-info --od`
+        export APT_OSS_version=`./bin/version-info --es`
+        OD_version=`./bin/version-info --od`
         export RPM_package_version=$OD_version
         export AMI_name="Open Distro for Elasticsearch-$OD_version-`date +"%D-%H.%M.%S"`"
         cd -

--- a/.github/workflows/test-build-deb.yml
+++ b/.github/workflows/test-build-deb.yml
@@ -68,15 +68,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Build Kibana deb
-        run: |
-          #!/bin/bash -x
-          set -e
-          set -u
-          cd kibana/linux_distributions
-          ./opendistro-kibana-build.sh deb
-          deb_artifact=`ls target/*.deb`
-          ls -ltr target/
-          aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistroforelasticsearch-kibana/
+        run: ./kibana/linux_distributions/opendistro-kibana-build.sh deb
 
   sign-deb-artifacts:
     needs: [build-es-artifacts, build-kibana-artifacts]
@@ -91,8 +83,7 @@ jobs:
       - name: Getting OD version
         id: version
         run: |
-          cd elasticsearch/bin
-          OD_VERSION=`./version-info --od`
+          OD_VERSION=`./bin/version-info --od`
           plugin_tag=v$OD_VERSION.0
           echo "::set-output name=p_tag::$plugin_tag"
 
@@ -157,9 +148,9 @@ jobs:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
         run: |
+          ES_VER=`./bin/version-info --es`
+          ODFE_VER=`./bin/version-info --od`
           cd elasticsearch/linux_distributions
-          ES_VER=`../bin/version-info --es`
-          ODFE_VER=`../bin/version-info --od`
           cd ../../..
           cd opendistro-infra/scripts/dockerfiles/tests/elasticsearch
           docker build --build-arg VER=$ES_VER -t opendistroforelasticsearch/elasticsearch-test-ubuntu:$ODFE_VER -f opendistro.elasticsearch.test.ubuntu.Dockerfile .
@@ -218,9 +209,9 @@ jobs:
 
       - name: Run Debian Staging Distrubution
         run: |
-          cd elasticsearch/linux_distributions
-          es_version=`../bin/version-info --es`
+          es_version=`./bin/version-info --es`
           echo $es_version
+          cd elasticsearch/linux_distributions
           cd ../../..
           sleep 20
           sudo sysctl -w vm.max_map_count=262144
@@ -273,9 +264,9 @@ jobs:
 
       - name: Run Debian Staging Distrubution
         run: |
-          cd elasticsearch/linux_distributions
-          es_version=`../bin/version-info --es`
+          es_version=`./bin/version-info --es`
           echo $es_version
+          cd elasticsearch/linux_distributions
           cd ../../..
           sleep 20
           sudo sysctl -w vm.max_map_count=262144
@@ -330,9 +321,9 @@ jobs:
 
       - name: Run Debian Staging Distrubution
         run: |
-          cd elasticsearch/linux_distributions
-          es_version=`../bin/version-info --es`
+          es_version=`./bin/version-info --es`
           echo $es_version
+          cd elasticsearch/linux_distributions
           cd ../../..
           sleep 20
           sudo sysctl -w vm.max_map_count=262144
@@ -385,9 +376,9 @@ jobs:
 
       - name: Run Debian Staging Distrubution
         run: |
-          cd elasticsearch/linux_distributions
-          es_version=`../bin/version-info --es`
+          es_version=`./bin/version-info --es`
           echo $es_version
+          cd elasticsearch/linux_distributions
           cd ../../..
           sleep 20
           sudo sysctl -w vm.max_map_count=262144
@@ -432,9 +423,9 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Run Debian Staging Distrubution
         run: |
-          cd elasticsearch/linux_distributions
-          es_version=`../bin/version-info --es`
+          es_version=`./bin/version-info --es`
           echo $es_version
+          cd elasticsearch/linux_distributions
           cd ../../..
           sleep 20
           sudo sysctl -w vm.max_map_count=262144

--- a/.github/workflows/test-build-rpm.yml
+++ b/.github/workflows/test-build-rpm.yml
@@ -69,15 +69,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Build Kibana rpm
-        run: |
-          #!/bin/bash -x
-          set -e
-          set -u
-          cd kibana/linux_distributions
-          ./opendistro-kibana-build.sh rpm
-          rpm_artifact=`ls target/*.rpm`
-          ls -ltr target/
-          aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistroforelasticsearch-kibana/
+        run: ./kibana/linux_distributions/opendistro-kibana-build.sh rpm
 
   signing-artifacts:   
     name: Sign Yum
@@ -125,9 +117,9 @@ jobs:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
         run: |
+          ES_VER=`./bin/version-info --es`
+          ODFE_VER=`./bin/version-info --od`
           cd elasticsearch/linux_distributions
-          ES_VER=`../bin/version-info --es`
-          ODFE_VER=`../bin/version-info --od`
           cd ../../..
           cd opendistro-infra/scripts/dockerfiles/tests/elasticsearch
           docker build --build-arg VER=$ODFE_VER -t opendistroforelasticsearch/elasticsearch-test-centos:$ODFE_VER -f opendistro.elasticsearch.test.centos.Dockerfile .
@@ -183,8 +175,7 @@ jobs:
       
       - name: Getting OD version
         run: |
-          cd elasticsearch/bin
-          OD_VERSION=`./version-info --od`
+          OD_VERSION=`./bin/version-info --od`
           echo "::set-env name=od_version::$OD_VERSION"
 
       - name: Starting ES service
@@ -222,8 +213,7 @@ jobs:
 
       - name: Getting OD Version
         run: |
-          cd elasticsearch/bin
-          OD_VERSION=`./version-info --od`
+          OD_VERSION=`./bin/version-info --od`
           plugin_tag=v$OD_VERSION.0
           echo "::set-env name=tag::$plugin_tag"
 

--- a/kibana/linux_distributions/opendistro-kibana-build.sh
+++ b/kibana/linux_distributions/opendistro-kibana-build.sh
@@ -139,8 +139,8 @@ if [ $# -eq 0 ] || [ "$PACKAGE_TYPE" = "rpm" ]; then
       # Upload to S3
       ls -ltr target/
       rpm_artifact=`ls target/*.rpm`
-      #aws s3 cp $rpm_artifact s3://$S3_BUCKET/downloads/rpms/opendistroforelasticsearch-kibana/
-      #aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"
+      aws s3 cp $rpm_artifact s3://$S3_BUCKET/downloads/rpms/opendistroforelasticsearch-kibana/
+      aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"
 
 fi
 
@@ -181,8 +181,8 @@ if [ $# -eq 0 ] || [ "$PACKAGE_TYPE" = "deb" ]; then
       # Upload to S3
       ls -ltr target/
       deb_artifact=`ls target/*.deb`
-      #aws s3 cp $deb_artifact s3://$S3_BUCKET/downloads/debs/opendistroforelasticsearch-kibana/
-      #aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"
+      aws s3 cp $deb_artifact s3://$S3_BUCKET/downloads/debs/opendistroforelasticsearch-kibana/
+      aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"
 
 fi
 
@@ -202,8 +202,8 @@ if [ $# -eq 0 ] || [ "$PACKAGE_TYPE" = "tar" ]; then
   ls -ltr target/
   tar_artifact=`ls target/*.tar.gz`
   tar_checksum_artifact=`ls target/*.tar.gz.sha512`
-  #aws s3 cp $tar_artifact s3://$S3_BUCKET/downloads/tarball/opendistroforelasticsearch-kibana/
-  #aws s3 cp $tar_checksum_artifact s3://$S3_BUCKET/downloads/tarball/opendistroforelasticsearch-kibana/
-  #aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"
+  aws s3 cp $tar_artifact s3://$S3_BUCKET/downloads/tarball/opendistroforelasticsearch-kibana/
+  aws s3 cp $tar_checksum_artifact s3://$S3_BUCKET/downloads/tarball/opendistroforelasticsearch-kibana/
+  aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"
 
 fi

--- a/kibana/linux_distributions/opendistro-kibana-build.sh
+++ b/kibana/linux_distributions/opendistro-kibana-build.sh
@@ -135,6 +135,13 @@ if [ $# -eq 0 ] || [ "$PACKAGE_TYPE" = "rpm" ]; then
       $ROOT/opendistroforelasticsearch-kibana/data/=/var/lib/kibana/ \
       $ROOT/service_templates/sysv/etc/=/etc/ \
       $ROOT/service_templates/systemd/etc/=/etc/
+
+      # Upload to S3
+      ls -ltr target/
+      rpm_artifact=`ls target/*.rpm`
+      #aws s3 cp $rpm_artifact s3://$S3_BUCKET/downloads/rpms/opendistroforelasticsearch-kibana/
+      #aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"
+
 fi
 
 if [ $# -eq 0 ] || [ "$PACKAGE_TYPE" = "deb" ]; then
@@ -170,6 +177,13 @@ if [ $# -eq 0 ] || [ "$PACKAGE_TYPE" = "deb" ]; then
       $ROOT/opendistroforelasticsearch-kibana/data/=/var/lib/kibana/ \
       $ROOT/service_templates/sysv/etc/=/etc/ \
       $ROOT/service_templates/systemd/etc/=/etc/
+
+      # Upload to S3
+      ls -ltr target/
+      deb_artifact=`ls target/*.deb`
+      #aws s3 cp $deb_artifact s3://$S3_BUCKET/downloads/debs/opendistroforelasticsearch-kibana/
+      #aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"
+
 fi
 
 if [ $# -eq 0 ] || [ "$PACKAGE_TYPE" = "tar" ]; then
@@ -188,8 +202,8 @@ if [ $# -eq 0 ] || [ "$PACKAGE_TYPE" = "tar" ]; then
   ls -ltr target/
   tar_artifact=`ls target/*.tar.gz`
   tar_checksum_artifact=`ls target/*.tar.gz.sha512`
-  aws s3 cp $tar_artifact s3://$S3_BUCKET/downloads/tarball/opendistroforelasticsearch-kibana/
-  aws s3 cp $tar_checksum_artifact s3://$S3_BUCKET/downloads/tarball/opendistroforelasticsearch-kibana/
-  aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"
+  #aws s3 cp $tar_artifact s3://$S3_BUCKET/downloads/tarball/opendistroforelasticsearch-kibana/
+  #aws s3 cp $tar_checksum_artifact s3://$S3_BUCKET/downloads/tarball/opendistroforelasticsearch-kibana/
+  #aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"
 
 fi


### PR DESCRIPTION
This PR is to reduce the complexity of the deb and rpm workflows/scripts.


------

### Test Cases:
- deb:
   https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/128969651
- rpm:
   https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/128988343

The bin directories in elasticsearch and kibana folder will be removed later, it is kept now until we make changes to all the scripts for backward compatibility.

