### PR TITLE
Move KNN lib to tarball distribution

### DIFF
--- a/elasticsearch/linux_distributions/opendistro-tar-build.sh
+++ b/elasticsearch/linux_distributions/opendistro-tar-build.sh
@@ -88,7 +88,7 @@ echo "Results: validated that plugins has been installed"
 # Download Knn lib 
 wget https://d3g5vo6xdbdb9a.cloudfront.net/downloads/k-NN-lib/libKNNIndexV1_7_3_6.zip \
 && unzip libKNNIndexV1_7_3_6.zip \
-&& mkdir -p $PACKAGE_NAME-$OD_VERSION/plugins/opendistro-knn/knn-lib/
+&& mkdir -p $PACKAGE_NAME-$OD_VERSION/plugins/opendistro-knn/knn-lib/ \
 && mv libKNNIndexV1_7_3_6.so $PACKAGE_NAME-$OD_VERSION/plugins/opendistro-knn/knn-lib/ \
 && rm libKNNIndexV1_7_3_6.zip
 

--- a/elasticsearch/linux_distributions/opendistro-tar-build.sh
+++ b/elasticsearch/linux_distributions/opendistro-tar-build.sh
@@ -85,6 +85,13 @@ for d in $PLUGINS_CHECKS; do
 done
 echo "Results: validated that plugins has been installed"
 
+# Download Knn lib 
+wget https://d3g5vo6xdbdb9a.cloudfront.net/downloads/k-NN-lib/libKNNIndexV1_7_3_6.zip \
+&& unzip libKNNIndexV1_7_3_6.zip \
+&& mkdir -p $PACKAGE_NAME-$OD_VERSION/plugins/opendistro-knn/knn-lib/
+&& mv libKNNIndexV1_7_3_6.so $PACKAGE_NAME-$OD_VERSION/plugins/opendistro-knn/knn-lib/ \
+&& rm libKNNIndexV1_7_3_6.zip
+
 # Tar generation
 echo "generating tar"
 tar -czf $TARGET_DIR/$PACKAGE_NAME-$OD_VERSION.tar.gz $PACKAGE_NAME-$OD_VERSION

--- a/elasticsearch/linux_distributions/opendistro-tar-install.sh
+++ b/elasticsearch/linux_distributions/opendistro-tar-install.sh
@@ -46,10 +46,8 @@ if sudo test -f "$FILE"; then
     echo "FILE EXISTS: removing $FILE"
     sudo rm $FILE
 fi
-wget https://d3g5vo6xdbdb9a.cloudfront.net/downloads/k-NN-lib/libKNNIndexV1_7_3_6.zip \
-&& unzip libKNNIndexV1_7_3_6.zip \
-&& sudo mv libKNNIndexV1_7_3_6.so /usr/lib \
-&& rm libKNNIndexV1_7_3_6.zip
+
+sudo cp $ES_HOME/plugins/opendistro-knn/knn-lib/libKNNIndexV1_7_3_6.so /usr/lib 
 
 ##Start Elastic Search
 bash $ES_HOME/bin/elasticsearch "$@"


### PR DESCRIPTION
### Description ###
Move knn lib to tarball distribution, and use install script to move this lib to right place at runtime. This is the short solution to avoid internet connectivity issue at runtime.

### Testing ###
Tested it locally. The lib will be included in tarball distribution. And the es service can start up successfully. But no testing for knn feature. This will be included in the building workflow
