### PR TITLE
Use custom lib path to replace /usr/lib

### DIFF
--- a/elasticsearch/linux_distributions/opendistro-tar-install.sh
+++ b/elasticsearch/linux_distributions/opendistro-tar-install.sh
@@ -13,7 +13,8 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-ES_HOME=`pwd`
+ES_HOME=`dirname $(realpath $0)`; cd $ES_HOME
+ES_KNN_LIB_DIR=$ES_HOME/plugins/opendistro-knn/knn-lib
 ##Security Plugin
 bash $ES_HOME/plugins/opendistro_security/tools/install_demo_configuration.sh -y -i -s
 
@@ -39,15 +40,23 @@ if ! grep -q '## OpenDistro Performance Analyzer' $ES_HOME/config/jvm.options; t
 fi
 echo "done plugins"
 
-#Move k-NN library in the /usr/lib
-echo "Fetching kNN library"
-FILE=/usr/lib/libKNNIndexV1_7_3_6.so
-if sudo test -f "$FILE"; then
-    echo "FILE EXISTS: removing $FILE"
-    sudo rm $FILE
+##Check KNN lib existence in ES TAR distribution
+echo "Checking kNN library"
+FILE=$ES_KNN_LIB_DIR/libKNNIndexV1_7_3_6.so
+if test -f "$FILE"; then
+    echo "FILE EXISTS $FILE"
+else
+    echo "TEST FAILED OR FILE NOT EXIST $FILE"
 fi
 
-sudo cp $ES_HOME/plugins/opendistro-knn/knn-lib/libKNNIndexV1_7_3_6.so /usr/lib 
+##Set KNN Dylib Path for LINUX, macOS uses DYLD_LIBRARY_PATH
+if echo "$LD_LIBRARY_PATH" | grep -q "$ES_KNN_LIB_DIR"; then
+    echo "KNN lib path has been set"
+else
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ES_KNN_LIB_DIR
+    echo "KNN lib path not found, set new path"
+    echo $LD_LIBRARY_PATH
+fi
 
 ##Start Elastic Search
 bash $ES_HOME/bin/elasticsearch "$@"


### PR DESCRIPTION
This PR is to follow up with the current KNN plugin changes to further optimize the process.
Instead of using /usr/lib to store the dylib file for KNN, we will export it to LD_LIBRARY_PATH (LINUX) as the lib file already has the correct naming convention to load from non-root owned directories. Also, macOS will use DYLD_LIBRARY_PATH here.

This would help with setups on shared (multi tenant) clusters without root.

This PR is depend on another PR here: https://github.com/opendistro-for-elasticsearch/opendistro-build/pull/269

### Test locally (ubuntu): ###
[knnlib_ld_nonroot.log](https://github.com/opendistro-for-elasticsearch/opendistro-build/files/4795511/knnlib_ld_nonroot.log)

