### PR TITLE
Enable 1.9.0 schedules for check_plugin workflow

### DIFF
--- a/.github/workflows/check_plugin.yml
+++ b/.github/workflows/check_plugin.yml
@@ -1,8 +1,8 @@
 name: Check Plugin Availability Main
 
 on:
-  #schedule:
-  #  - cron: '0 0,15 * * *'
+  schedule:
+    - cron: '0 0,15 * * *'
 
   repository_dispatch:
     types: [check_plugin]


### PR DESCRIPTION
This PR is to enable 1.9.0 schedules for check_plugin workflow.