### PR TITLE
Release CI Docker Test Images for Plugin Teams

### DIFF
--- a/.github/workflows/test-build-docker-ci.yml
+++ b/.github/workflows/test-build-docker-ci.yml
@@ -1,4 +1,4 @@
-name: Webhook Build ES Docker on Dispatch
+name: Webhook Build ES Docker CI on Dispatch
 
 on: 
   schedule:

--- a/.github/workflows/test-build-docker-ci.yml
+++ b/.github/workflows/test-build-docker-ci.yml
@@ -1,0 +1,162 @@
+name: Webhook Build ES Docker on Dispatch
+
+on: 
+  schedule:
+    - cron: '0 0,15 * * *'
+  repository_dispatch:
+    types: [test-build-docker-ci]
+  push:
+    branch: [opendistro-infra-issue-179-1]
+
+jobs:
+  build-es-docker:
+    strategy:
+      matrix:
+        java: [14]
+    name: Build ES Docker
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Configure AWS
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+
+    - name: Set Up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+
+    - name: Starting ES Docker Build
+      env:
+        DOCKER_USER: ${{ secrets.DOCKER_USER }}
+        DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+      run: |
+        echo "Executing On-demand Build for ES Docker Image"
+        ODFE_VER=`./bin/version-info --od`
+        echo "ODFE VERSION $ODFE_VER"
+        workdir=`pwd`
+        sudo apt-get install python-virtualenv
+        ./download_plugins.sh
+        cd elasticsearch
+        security=`ls docker/build/elasticsearch/plugins/|grep opendistro_security|wc -l`
+        
+        if [ $security -gt 0 ]
+        then
+           echo "Security plugin is available"
+        else
+           echo "Security plugin is NOT available"
+        fi
+        
+        cd docker
+        make build
+        
+        echo "******************************"
+        echo "Login to Docker"
+        echo "******************************"
+        docker login --username $DOCKER_USER --password $DOCKER_PASS
+        docker images|grep "amazon/opendistro-for-elasticsearch" > docker_id.out
+        image_id=`awk -F ' ' '{print $3}' docker_id.out`
+        echo "Docker Id is $image_id"
+        docker tag $image_id opendistroforelasticsearch/opendistroforelasticsearch-ci:$ODFE_VER
+        docker images
+        docker push opendistroforelasticsearch/opendistroforelasticsearch-ci:$ODFE_VER
+        #echo "<h2>The docker image opendistroforelasticsearch/opendistroforelasticsearch-ci:$ODFE_VER for ODFE has been created and uploaded to docker-hub</h2>" >> $workdir/Release.md
+        cd ../../..
+        ls -ltr
+        
+        #Run Docker Container without security
+        if [ $security -gt 0 ]
+        then
+           echo "Running newly tagged image with no security"
+           echo "FROM opendistroforelasticsearch/opendistroforelasticsearch-ci:$ODFE_VER" >> Dockerfile
+           echo "RUN /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security" >> Dockerfile
+           docker build -t odfe-http:no-security .
+           sleep 5
+     
+           docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" odfe-http:no-security
+        else
+           echo "Running originially created docker image"
+           docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" opendistroforelasticsearch/opendistroforelasticsearch-ci:$ODFE_VER
+        fi
+    
+    - name: Create Email Message
+      run: |
+        echo "<h2>On-Demand Opendsitro Docker Image (CI) is Ready</h2>" >> Message.md
+        echo "<h3>Docker Image: opendistroforelasticsearch/opendistroforelasticsearch-ci:<VERSION-TAG></h3>" >> Message.md
+    
+    - name: Send Email
+      uses: dawidd6/action-send-mail@master
+      with:
+        server_address: smtp.gmail.com
+        server_port: 465
+        username: ${{secrets.MAIL_USERNAME}}
+        password: ${{secrets.MAIL_PASSWORD}}
+        subject: Opendistro for Elasticsearch Build - On-Demand ODFE Image is Ready
+        # Read file contents as body:
+        body: file://Message.md
+        to: odfe-distribution-build@amazon.com
+        from: Opendistro Elasticsearch
+        # Optional content type:
+        content_type: text/html
+          
+  build-kibana-docker:
+    runs-on: [ubuntu-16.04]
+    name: Build Kibana Docker
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Build Kibana Docker
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+        run: |
+          sudo apt-get install python-virtualenv
+          ODFE_VER=`./bin/version-info --od`
+          echo "ODFE VERSION $ODFE_VER"
+          ./download_kibana_plugins.sh
+          cd kibana
+          cd docker
+          make build
+          
+          echo "******************************"
+          echo "Uploading Kibana Docker"
+          echo "******************************"
+          docker login --username $DOCKER_USER --password $DOCKER_PASS
+          docker images|grep "amazon/opendistro-for-elasticsearch-kibana" > kibana_id.out
+          kibana_image_id=`awk -F ' ' '{print $3}' kibana_id.out`
+          echo "Docker Id is $kibana_image_id"
+          docker tag $kibana_image_id opendistroforelasticsearch/opendistroforelasticsearch-kibana-ci:$ODFE_VER
+          docker images
+          docker push opendistroforelasticsearch/opendistroforelasticsearch-kibana-ci:$ODFE_VER
+          
+      - name: Create Email Message
+        run: |
+          echo "<h2>On-Demand Opendsitro Kibana Docker Image (CI) is Ready</h2>" >> Message.md
+          echo "<h3>Docker Image: opendistroforelasticsearch/opendistroforelasticsearch-kibana-ci:<VERSION-TAG></h3>" >> Message.md
+          
+      - name: Send Email
+        uses: dawidd6/action-send-mail@master
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{secrets.MAIL_USERNAME}}
+          password: ${{secrets.MAIL_PASSWORD}}
+          subject: Opendistro for Elasticsearch Build - On-Demand ODFE Kibana Image
+          # Read file contents as body:
+          body: file://Message.md
+          to: odfe-distribution-build@amazon.com
+          from: Opendistro Elasticsearch
+          # Optional content type:
+          content_type: text/html
+        
+         

--- a/.github/workflows/test-build-docker-ci.yml
+++ b/.github/workflows/test-build-docker-ci.yml
@@ -5,8 +5,6 @@ on:
     - cron: '0 0,15 * * *'
   repository_dispatch:
     types: [test-build-docker-ci]
-  push:
-    branch: [opendistro-infra-issue-179-1]
 
 jobs:
   build-es-docker:

--- a/download_kibana_plugins.sh
+++ b/download_kibana_plugins.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-set -e
+
+# Please do not change this comment
+# Script will download even when artifacts are not fully available
+#set -e
 REPO_ROOT=`git rev-parse --show-toplevel`
 ROOT=`dirname $(realpath $0)`; echo $ROOT; cd $ROOT
 ES_VERSION=`$REPO_ROOT/bin/version-info --es`; echo $ES_VERSION
@@ -20,7 +23,7 @@ for plugin_path in $PLUGINS
 do
   plugin_latest=`aws s3api list-objects --bucket artifacts.opendistroforelasticsearch.amazon.com --prefix "downloads/kibana-plugins/${plugin_path}" --query 'Contents[].[Key]' --output text | sort | tail -n 1`
   echo "downloading $plugin_latest"
-  echo `echo $plugin_latest | awk -F '/' '{print $NF}'` >> $PLUGIN_DIR/plugins_kibana.list
+  (echo $plugin_latest | grep -qhi 'None') || (echo `echo $plugin_latest | awk -F '/' '{print $NF}'` >> $PLUGIN_DIR/plugins_kibana.list)
   aws s3 cp "s3://artifacts.opendistroforelasticsearch.amazon.com/${plugin_latest}" "${PLUGIN_DIR}" --quiet; echo $?
 done
 

--- a/download_plugins.sh
+++ b/download_plugins.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-set -e
+
+# Please do not change this comment
+# Script will download even when artifacts are not fully available
+#set -e
 REPO_ROOT=`git rev-parse --show-toplevel`
 ROOT=`dirname $(realpath $0)`; echo $ROOT; cd $ROOT
 ES_VERSION=`$REPO_ROOT/bin/version-info --es`; echo $ES_VERSION
@@ -24,7 +27,7 @@ for plugin_path in $PLUGINS
 do
   plugin_latest=`aws s3api list-objects --bucket artifacts.opendistroforelasticsearch.amazon.com --prefix "downloads/elasticsearch-plugins/${plugin_path}" --query 'Contents[].[Key]' --output text | sort | tail -n 1`
   echo "downloading $plugin_latest"
-  echo `echo $plugin_latest | awk -F '/' '{print $NF}'` >> $PLUGIN_DIR/plugins.list
+  (echo $plugin_latest | grep -qhi 'None') || (echo `echo $plugin_latest | awk -F '/' '{print $NF}'` >> $PLUGIN_DIR/plugins.list)
   aws s3 cp "s3://artifacts.opendistroforelasticsearch.amazon.com/${plugin_latest}" "${PLUGIN_DIR}" --quiet; echo $?
 done
 


### PR DESCRIPTION
This PR is to release the CI Docker Test Images for Plugin Teams to run tests before all the plugins artifacts are available.

### Test Cases: ###
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/144181876
(ES failed because KNN 1.9.0 not available as of now)