### PR TITLE
Adding testing domain setup and teardown infra

### DIFF
--- a/.github/scripts/userdata.sh
+++ b/.github/scripts/userdata.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+set -e
+REPO_ROOT=`git rev-parse --show-toplevel`
+ES_VER=`$REPO_ROOT/bin/version-info --es`
+ODFE_VER=`$REPO_ROOT/bin/version-info --od`
+echo $ES_VER $ODFE_VER
+
+if [ "$#" -eq 0 ] || [ "$#" -gt 2 ] || [ -z "$1" ] || [ -z "$2" ]
+then
+    echo "Please assign 2 parameters when running this script"
+    echo "Format for dispatch event: \"client_payload\": {
+		\"distribution\" : \"rpm\",
+		\"security\" : \"enable\"
+	}"
+    echo "Example: $0 \"RPM\" \"ENABLE\""
+    echo "Example: $0 \"DEB\" \"DISABLE\""
+    exit 1
+fi
+
+###### RPM package with Security enabled ######
+if [ "$1" = "RPM" ]
+then
+cat <<- EOF > $REPO_ROOT/userdata_$1.sh
+#!/bin/bash
+sudo -i
+sudo curl https://d3g5vo6xdbdb9a.cloudfront.net/yum/staging-opendistroforelasticsearch-artifacts.repo -o /etc/yum.repos.d/staging-opendistroforelasticsearch-artifacts.repo
+sudo yum install -y opendistroforelasticsearch-$ODFE_VER
+sudo sysctl -w vm.max_map_count=262144
+echo "node.name: init-master" >> /etc/elasticsearch/elasticsearch.yml
+echo "cluster.name: odfe-$ODFE_VER-rpm-auth" >> /etc/elasticsearch/elasticsearch.yml
+echo "network.host: 0.0.0.0" >> /etc/elasticsearch/elasticsearch.yml
+echo "cluster.initial_master_nodes: [\"init-master\"]" >> /etc/elasticsearch/elasticsearch.yml
+
+# Start the service
+sudo systemctl start elasticsearch.service
+sleep 30
+
+# Installing kibana
+sudo yum install -y opendistroforelasticsearch-kibana-$ODFE_VER
+echo "server.host: 0.0.0.0" >> /etc/kibana/kibana.yml
+EOF
+fi
+
+###### DEB package with Security enabled ######
+if [ "$1" = "DEB" ]
+then 
+cat <<- EOF > $REPO_ROOT/userdata_$1.sh
+#!/bin/bash
+#installing ODFE
+sudo -i
+sudo sysctl -w vm.max_map_count=262144
+sudo apt-get install -y zip
+wget -qO - https://d3g5vo6xdbdb9a.cloudfront.net/GPG-KEY-opendistroforelasticsearch | sudo apt-key add -
+echo "deb https://d3g5vo6xdbdb9a.cloudfront.net/staging/apt stable main" | sudo tee -a /etc/apt/sources.list.d/opendistroforelasticsearch.list
+wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$ES_VER-amd64.deb
+sudo dpkg -i elasticsearch-oss-$ES_VER-amd64.deb
+sudo apt-get -y update
+sudo apt install -y opendistroforelasticsearch
+echo "node.name: init-master" >> /etc/elasticsearch/elasticsearch.yml
+echo "cluster.initial_master_nodes: [\"init-master\"]" >> /etc/elasticsearch/elasticsearch.yml
+echo "cluster.name: odfe-$ODFE_VER-deb-auth" >> /etc/elasticsearch/elasticsearch.yml
+echo "network.host: 0.0.0.0" >> /etc/elasticsearch/elasticsearch.yml
+
+# Start the service
+sudo /etc/init.d/elasticsearch start
+sleep 30
+
+# Installing kibana
+sudo apt install opendistroforelasticsearch-kibana
+echo "server.host: 0.0.0.0" >> /etc/kibana/kibana.yml
+
+EOF
+fi
+
+###### TAR package with Security enabled ######
+if [ "$1" = "TAR" ]
+then 
+cat <<- EOF > $REPO_ROOT/userdata_$1.sh
+#!/bin/bash
+echo "*   hard  nofile  65535" | tee --append /etc/security/limits.conf
+echo "*   soft  nofile  65535" | tee --append /etc/security/limits.conf
+sudo apt-get install -y zip
+ulimit -n 65535
+wget https://d3g5vo6xdbdb9a.cloudfront.net/downloads/tarball/opendistro-elasticsearch/opendistroforelasticsearch-$ODFE_VER.tar.gz
+tar zxvf opendistroforelasticsearch-$ODFE_VER.tar.gz
+chown -R ubuntu:ubuntu opendistroforelasticsearch-$ODFE_VER
+cd opendistroforelasticsearch-$ODFE_VER/
+
+echo "node.name: init-master" >> config/elasticsearch.yml
+echo "cluster.initial_master_nodes: [\"init-master\"]" >> config/elasticsearch.yml
+echo "cluster.name: odfe-$ODFE_VER-tarball-auth" >> config/elasticsearch.yml
+echo "network.host: 0.0.0.0" >> config/elasticsearch.yml
+sudo sysctl -w vm.max_map_count=262144
+sudo -u ubuntu nohup ./opendistro-tar-install.sh 2>&1 > /dev/null &
+
+#Installing kibana
+cd /
+wget https://d3g5vo6xdbdb9a.cloudfront.net/downloads/tarball/opendistroforelasticsearch-kibana/opendistroforelasticsearch-kibana-$ODFE_VER.tar.gz
+tar zxvf opendistroforelasticsearch-kibana-$ODFE_VER.tar.gz
+chown -R ubuntu:ubuntu opendistroforelasticsearch-kibana
+cd opendistroforelasticsearch-kibana/
+echo "server.host: 0.0.0.0" >> config/kibana.yml
+EOF
+fi
+
+#### Security disable feature ####
+if  [[ "$2" = "DISABLE" ]]
+then
+if [[ "$1" = "RPM"  ||  "$1" = "DEB" ]]
+then
+sed -i "s/^echo \"cluster.name.*/echo \"cluster.name \: odfe-$ODFE_VER-$1-noauth\" \>\> \/etc\/elasticsearch\/elasticsearch.yml/g" $REPO_ROOT/userdata_$1.sh
+sed -i "/echo \"network.host/a echo \"opendistro_security.disabled: true\" \>\> \/etc\/elasticsearch\/elasticsearch.yml" $REPO_ROOT/userdata_$1.sh
+cat <<- EOF >> userdata_$1.sh
+sudo rm -rf /usr/share/kibana/plugins/opendistro_security
+sudo sed -i /^opendistro_security/d /etc/kibana/kibana.yml
+sudo sed -i 's/https/http/' /etc/kibana/kibana.yml
+EOF
+else
+sed -i "s/^echo \"cluster.name.*/echo \"cluster.name \: odfe-$ODFE_VER-$1-noauth\" \>\> config\/elasticsearch.yml/g" $REPO_ROOT/userdata_$1.sh
+sed -i "/echo \"network.host/a echo \"opendistro_security.disabled: true\" \>\> config\/elasticsearch.yml" $REPO_ROOT/userdata_$1.sh
+cat <<- EOF >> userdata_$1.sh
+sudo rm -rf plugins/opendistro_security
+sed -i /^opendistro_security/d config/kibana.yml
+sed -i 's/https/http/' config/kibana.yml
+EOF
+fi
+fi
+
+#Start Kibana
+if [[ "$1" = "RPM"  ||  "$1" = "DEB" ]]
+then
+echo "sudo systemctl start kibana.service" >> $REPO_ROOT/userdata_$1.sh
+else
+echo "sudo -u ubuntu nohup ./bin/kibana &" >> $REPO_ROOT/userdata_$1.sh
+fi

--- a/.github/templates/odfe-testing-cluster-template.json
+++ b/.github/templates/odfe-testing-cluster-template.json
@@ -1,0 +1,238 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "ODFE testing cluster set-up",
+  
+  
+    "Parameters": {
+
+        "userdata":{
+            "Type": "String",
+            "Description": "Script to install ODFE and Kibana"
+        },
+        "distribution":{
+            "Type": "String",
+            "Description": "Testing distribution name (RPM/DEB/TAR)",
+            "Default" : "RPM",
+            "AllowedValues" : ["RPM", "DEB", "TAR"]
+        },
+        "security":{
+            "Type": "String",
+            "Default" : "ENABLE",
+            "AllowedValues" : [ "ENABLE", "DISABLE" ],
+            "Description": "Security feature enabled"
+        },
+        "vpcId":{
+            "Type": "String",
+            "Description": "VPC id associated with the cluster"
+        },
+
+        "ODFESecurityGroup":{
+            "Type" : "String",
+            "Description": "Security Group id to be attached to all the resources"
+        },
+        "keypair":{
+            "Type" : "String",
+            "Description": "Security Group id to be attached to all the resources"
+        }
+  
+    },
+
+    "Mappings" : {
+        "DistributionMap" : {
+          "RPM" : { "amiId" : "ami-0e34e7b9ca0ace12d" },
+          "TAR" : { "amiId" : "ami-003634241a8fcdec0" },
+          "DEB" : { "amiId" : "ami-003634241a8fcdec0" }
+        }
+      },
+
+    "Conditions" : {
+        "CreateSecurityResources" : {"Fn::Equals" : [{"Ref" : "security"}, "ENABLE"]},
+        "CreateDisableSecurityResources" : {"Fn::Equals" : [{"Ref" : "security"}, "DISABLE"]}
+    },
+  
+    "Resources": {         
+  
+        "ODFEASG" : {
+            "Type" : "AWS::AutoScaling::AutoScalingGroup",
+            "Properties" : {
+                "AvailabilityZones" : [ "us-west-2a","us-west-2b","us-west-2c","us-west-2d"  ],
+                "LaunchConfigurationName" : { "Ref" : "asgLaunchConfig" },
+                "MinSize" : "1",
+                "MaxSize" : "1",
+                "DesiredCapacity" : "1",
+                "TargetGroupARNs": [{"Fn::If": ["CreateSecurityResources", {"Ref" : "ESSTargetGroup"}, {"Ref":"ESTargetGroup"}]}, 
+                        {"Ref":"KibanaTargetGroup"}],
+                "Tags":[{
+                    "Key" : "Name", 
+                    "Value" : {
+                        "Fn::Join": [
+                          "", [
+                            "ODFE-",
+                            {
+                              "Ref": "distribution"
+                            },
+                            "-SECURITY-",
+                            {
+                                "Ref": "security"
+                            },
+                            "-Testing-Cluster"
+                          ]
+                        ]
+                      }, 
+                    "PropagateAtLaunch" : "true"}]
+                }
+            },
+
+        "asgLaunchConfig":{
+              "Type": "AWS::AutoScaling::LaunchConfiguration",
+              "Properties": {
+                  "ImageId": { "Fn::FindInMap" : [ "DistributionMap", { "Ref" : "distribution" }, "amiId"]},
+                  "InstanceType": "m5a.large",
+                  "IamInstanceProfile": "odfe_testing_cluster_role",
+                  "KeyName": {"Ref" : "keypair"},
+                  "AssociatePublicIpAddress": true,
+                  "SecurityGroups": [{"Ref" : "ODFESecurityGroup"}],
+                  "UserData": {
+                      "Ref": "userdata"}
+                  
+                }
+        },
+
+
+        "ESLoadBalancer" : {
+            "Type" : "AWS::ElasticLoadBalancingV2::LoadBalancer",
+            "Condition" : "CreateDisableSecurityResources",
+            "Properties" : {
+                "Name" : { "Fn::Join": [
+                    "", [
+                      "ODFE-ES-",
+                      {
+                        "Ref": "distribution"
+                      },
+                      "-SECURITY-",
+                      {
+                          "Ref": "security"
+                      }]
+                  ]},
+                "Scheme" : "internet-facing",
+                "SecurityGroups" : [{"Ref" : "ODFESecurityGroup"}] ,
+                "Subnets": ["subnet-48b6f163","subnet-9cb844e4","subnet-d9d21d84","subnet-eeffe1a5"],
+                "Type" : "application"
+                }
+        },
+
+        "ESListener" : {
+            "Type" : "AWS::ElasticLoadBalancingV2::Listener",
+            "Condition" : "CreateDisableSecurityResources",
+            "Properties" : {
+                "DefaultActions" : [{
+                "Type" : "forward",
+                "TargetGroupArn" : { "Ref" : "ESTargetGroup" }
+                }],
+                "LoadBalancerArn" : { "Ref" : "ESLoadBalancer" },
+                "Port" : "80",
+                "Protocol" : "HTTP"
+                }
+      },
+
+        "ESTargetGroup" : {
+            "Type" : "AWS::ElasticLoadBalancingV2::TargetGroup",
+            "Condition" : "CreateDisableSecurityResources",
+            "Properties" : {
+                "HealthCheckEnabled" : "True",
+                "Port" : 9200,
+                "HealthCheckPath" : "/",
+                "Protocol" : "HTTP",
+                "VpcId" : {"Ref" : "vpcId"}
+                }
+      },
+        "KibanaLoadBalancer" : {
+            "Type" : "AWS::ElasticLoadBalancingV2::LoadBalancer",
+            "Properties" : {
+                "Name" : { "Fn::Join": [
+                    "", [
+                      "ODFE-KIBANA-",
+                      {
+                        "Ref": "distribution"
+                      },
+                      "-SECURITY-",
+                      {
+                          "Ref": "security"
+                      }]
+                  ]},
+                "Scheme" : "internet-facing",
+                "SecurityGroups" : [{"Ref" : "ODFESecurityGroup"}],
+                "Subnets": ["subnet-48b6f163","subnet-9cb844e4","subnet-d9d21d84","subnet-eeffe1a5"],
+                "Type" : "application"
+                }
+        },
+
+        "KibanaListener" : {
+            "Type" : "AWS::ElasticLoadBalancingV2::Listener",
+            "Properties" : {
+                "DefaultActions" : [{
+                "Type" : "forward",
+                "TargetGroupArn" : { "Ref" : "KibanaTargetGroup" }
+                }],
+                "LoadBalancerArn" : { "Ref" : "KibanaLoadBalancer" },
+                "Port" : "80",
+                "Protocol" : "HTTP"
+                }
+    },
+
+        "KibanaTargetGroup" : {
+            "Type" : "AWS::ElasticLoadBalancingV2::TargetGroup",
+            "Properties" : {
+                "HealthCheckEnabled" : "True",
+                "Port" : 5601,
+                "HealthCheckPath" : "/api/status",
+                "Protocol" : "HTTP",
+                "VpcId" : {"Ref" : "vpcId"}
+                }
+    },
+
+        "ESSLoadBalancer" : {
+            "Type" : "AWS::ElasticLoadBalancingV2::LoadBalancer",
+            "Condition" : "CreateSecurityResources",
+            "Properties" : {
+                "Name" : { "Fn::Join": [
+                    "", [
+                      "ODFE-ES-",
+                      {
+                        "Ref": "distribution"
+                      },
+                      "-SECURITY-",
+                      {
+                          "Ref": "security"
+                      }]
+                  ]},
+                "Scheme" : "internet-facing",
+                "Subnets": ["subnet-48b6f163","subnet-9cb844e4","subnet-d9d21d84","subnet-eeffe1a5"],
+                "Type" : "network"
+            }
+        },
+        "ESSListener" : {
+            "Type" : "AWS::ElasticLoadBalancingV2::Listener",
+            "Condition" : "CreateSecurityResources",
+            "Properties" : {
+                "DefaultActions" : [{
+                "Type" : "forward",
+                "TargetGroupArn" : { "Ref" : "ESSTargetGroup" }
+                }],
+                "LoadBalancerArn" : { "Ref" : "ESSLoadBalancer" },
+                "Port" : "443",
+                "Protocol" : "TCP"
+                }
+        },
+        "ESSTargetGroup" : {
+            "Type" : "AWS::ElasticLoadBalancingV2::TargetGroup",
+            "Condition" : "CreateSecurityResources",
+            "Properties" : {
+                "Port" : 9200,
+                "Protocol" : "TCP",
+                "VpcId" : {"Ref" : "vpcId"}
+            }
+        }
+    }
+
+}

--- a/.github/workflows/test-cluster-delete.yml
+++ b/.github/workflows/test-cluster-delete.yml
@@ -1,0 +1,39 @@
+# Alert: This workflow will delete "ALL" the ODFE testing cluster stacks
+name: Delete testing clusters
+on:
+  repository_dispatch:
+    types: [test-cluster-delete]
+
+jobs:
+  Create-Cluster:
+    name: Delete Testing cluster
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.STACK_KEY }}
+          aws-secret-access-key: ${{ secrets.STACK_SECRET }}
+          aws-region: us-west-2
+
+      - name: Deleting all ODFE clusters
+        run: |
+            #!/bin/bash
+            set -e
+            stacks=`aws cloudformation list-stacks --stack-status-filter CREATE_COMPLETE --query 'StackSummaries[*].StackName' --output text`
+            echo "#######################################"
+            echo $stacks | tr " " "\n"
+            echo "#######################################"
+
+            for i in $stacks
+            do
+                if [[ $i = ODFE-* ]] 
+                then
+                    echo "Deleting $i stack"
+                    aws cloudformation delete-stack --stack-name $i
+                    aws cloudformation wait stack-delete-complete --stack-name $i
+                    echo "$i stack deleted successfully!!"
+                fi
+            done

--- a/.github/workflows/test-cluster-set-up.yml
+++ b/.github/workflows/test-cluster-set-up.yml
@@ -1,10 +1,8 @@
 name: Create testing cluster
 
-# Make sure to pass the distribution type and security feature as parameters
-# { 
-#  "distribution": "RPM/DEB/TAR",
-#  "security": "enable/disable"
-# }
+# Make sure to pass the distribution type (RPM/DEB/TAR) and security feature (enable, disable) as client_payload in the dispatch event
+# Example: client_payload: { "distribution": "rpm", "security": "enable" }
+# Example: client_payload: { "distribution": "deb", "security": "disable" }
 
 on:
   repository_dispatch:

--- a/.github/workflows/test-cluster-set-up.yml
+++ b/.github/workflows/test-cluster-set-up.yml
@@ -1,0 +1,70 @@
+name: Create testing cluster
+
+# Make sure to pass the distribution type and security feature as parameters
+# { 
+#  "distribution": "RPM/DEB/TAR",
+#  "security": "enable/disable"
+# }
+
+on:
+  repository_dispatch:
+    types: [test-cluster-set-up]
+
+jobs:
+  Create-Cluster:
+    name: Create Testing cluster
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.STACK_KEY }}
+          aws-secret-access-key: ${{ secrets.STACK_SECRET }}
+          aws-region: us-west-2
+
+      - name: Creating cluster
+        run: |
+            #!/bin/bash
+            set -e
+
+            distribution_type=`echo ${{github.event.client_payload.distribution}} | tr [:lower:] [:upper:]`
+            security=`echo ${{github.event.client_payload.security}} | tr [:lower:] [:upper:]`
+            echo $distribution_type $security
+            stackName=ODFE-$distribution_type-SECURITY-$security
+
+            existingStacks=`aws cloudformation list-stacks --stack-status-filter CREATE_COMPLETE --query 'StackSummaries[*].StackName' --output text`
+
+            for i in $existingStacks
+            do
+                if [[ $i = $stackName ]]
+                then
+                    echo "Stack already exists! Deleting the old stack"
+                    aws cloudformation delete-stack --stack-name $stackName
+                    aws cloudformation wait stack-delete-complete --stack-name $stackName
+                    echo "$stackName deleted successfully!!"
+                fi
+            done
+            
+            .github/scripts/userdata.sh "$distribution_type" "$security"
+            ls -ltr
+
+            echo "Creating $stackName stack"
+
+            aws cloudformation create-stack --stack-name $stackName \
+            --template-body file://.github/templates/odfe-testing-cluster-template.json \
+            --parameters ParameterKey=userdata,ParameterValue=$(base64 -w0 userdata_$distribution_type.sh) \
+            ParameterKey=distribution,ParameterValue=$distribution_type \
+            ParameterKey=security,ParameterValue=$security \
+            ParameterKey=vpcId,ParameterValue=${{secrets.VPCID}} \
+            ParameterKey=ODFESecurityGroup,ParameterValue=${{secrets.ODFESECURITYGROUP}} \
+            ParameterKey=keypair,ParameterValue=${{secrets.AWS_ODFE_TESTING_CLUSTER_KEYPAIR}}
+
+            aws cloudformation wait stack-create-complete --stack-name $stackName
+            sleep 60
+            echo "################################################################################################"
+            echo "Elasticsearch endpoint = `aws elbv2 describe-load-balancers --name ODFE-ES-$distribution_type-SECURITY-$security --query 'LoadBalancers[*].DNSName' --output text`"
+            echo "################################################################################################"
+            echo "Kibana endpoint = `aws elbv2 describe-load-balancers --name ODFE-KIBANA-$distribution_type-SECURITY-$security --query 'LoadBalancers[*].DNSName' --output text`"
+            echo "################################################################################################"

--- a/.github/workflows/test-cluster-set-up.yml
+++ b/.github/workflows/test-cluster-set-up.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.STACK_KEY }}
-          aws-secret-access-key: ${{ secrets.STACK_SECRET }}
+          aws-access-key-id: ${{ secrets.AWS_STACK_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_STACK_SECRET }}
           aws-region: us-west-2
 
       - name: Creating cluster


### PR DESCRIPTION
This PR adds infrastructure set up for testing domains that the plugins team will use during the staging stage of the release.

- [Tested Set up](https://github.com/gaiksaya/opendistro-build/actions/runs/146579537)

- [Tested tear down](https://github.com/gaiksaya/opendistro-build/actions/runs/146610299)

Necessary secrets will be added to the repo.

**Note**: The delete workflow will be used to delete all the testing clusters (mostly after the release).