### PR TITLE
Adding infra for testing clusters with static domain

### DIFF
--- a/.github/templates/odfe-testing-cluster-static-domain-template.json
+++ b/.github/templates/odfe-testing-cluster-static-domain-template.json
@@ -1,0 +1,105 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "ODFE testing cluster set-up",
+  
+  
+    "Parameters": {
+
+        "userdata":{
+            "Type": "String",
+            "Description": "Script to install ODFE and Kibana"
+        },
+
+        "distribution":{
+            "Type": "String",
+            "Description": "Testing distribution name (RPM/DEB/TAR)",
+            "Default" : "RPM",
+            "AllowedValues" : ["RPM", "DEB", "TAR"]
+        },
+
+        "security":{
+            "Type": "String",
+            "Default" : "ENABLE",
+            "AllowedValues" : [ "ENABLE", "DISABLE" ],
+            "Description": "Security feature enabled"
+        },
+
+        "ODFESecurityGroup":{
+            "Type" : "String",
+            "Description": "Security Group id to be attached to all the resources"
+        },
+
+        "keypair":{
+            "Type" : "String",
+            "Description": "Security Group id to be attached to all the resources"
+        },
+
+        "esTargetGroup":{
+            "Type" : "String",
+            "Description": "ES Target Group ARN"
+        },
+        
+        "kibanaTargetGroup":{
+            "Type" : "String",
+            "Description": "Kibana Target Group ARN"
+        }
+  
+    },
+
+    "Mappings" : {
+        "DistributionMap" : {
+          "RPM" : { "amiId" : "ami-0e34e7b9ca0ace12d" },
+          "TAR" : { "amiId" : "ami-003634241a8fcdec0" },
+          "DEB" : { "amiId" : "ami-003634241a8fcdec0" }
+        }
+      },
+
+     "Resources": {         
+  
+        "ODFEASG" : {
+            "Type" : "AWS::AutoScaling::AutoScalingGroup",
+            "Properties" : {
+                "AvailabilityZones" : [ "us-west-2a","us-west-2b","us-west-2c","us-west-2d"  ],
+                "LaunchConfigurationName" : { "Ref" : "asgLaunchConfig" },
+                "MinSize" : "1",
+                "MaxSize" : "1",
+                "DesiredCapacity" : "1",
+                "TargetGroupARNs": [{"Ref" : "esTargetGroup"}, {"Ref":"kibanaTargetGroup"}],
+                "Tags":[{
+                    "Key" : "Name", 
+                    "Value" : {
+                        "Fn::Join": [
+                          "", [
+                            "ODFE-",
+                            {
+                              "Ref": "distribution"
+                            },
+                            "-SECURITY-",
+                            {
+                                "Ref": "security"
+                            },
+                            "-Testing-Cluster"
+                          ]
+                        ]
+                      }, 
+                    "PropagateAtLaunch" : "true"}]
+                }
+            },
+
+        "asgLaunchConfig":{
+              "Type": "AWS::AutoScaling::LaunchConfiguration",
+              "Properties": {
+                  "ImageId": { "Fn::FindInMap" : [ "DistributionMap", { "Ref" : "distribution" }, "amiId"]},
+                  "InstanceType": "m5a.large",
+                  "IamInstanceProfile": "odfe_testing_cluster_role",
+                  "KeyName": {"Ref" : "keypair"},
+                  "AssociatePublicIpAddress": true,
+                  "SecurityGroups": [{"Ref" : "ODFESecurityGroup"}],
+                  "UserData": {
+                      "Ref": "userdata"}
+                  
+                }
+        }
+    }
+
+}

--- a/.github/workflows/test-cluster-static-domain-set-up.yml
+++ b/.github/workflows/test-cluster-static-domain-set-up.yml
@@ -1,0 +1,70 @@
+name: Create testing cluster with static domain
+
+# Make sure to pass the distribution type (RPM/DEB/TAR) and security feature (enable, disable) as client_payload in the dispatch event
+# Example: client_payload: { "distribution": "rpm", "security": "enable" }
+# Example: client_payload: { "distribution": "deb", "security": "disable" }
+# NOTE: This workflow is based on the static ELBs pre-configured in the AWS account
+
+on:
+  repository_dispatch:
+    types: [test-cluster-static-domain]
+
+jobs:
+  Create-Cluster:
+    name: Create Testing cluster
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_STACK_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_STACK_SECRET }}
+          aws-region: us-west-2
+
+      - name: Creating cluster with static domain name
+        run: |
+            #!/bin/bash
+            set -e
+
+            distribution_type=`echo ${{github.event.client_payload.distribution}} | tr [:lower:] [:upper:]`
+            security=`echo ${{github.event.client_payload.security}} | tr [:lower:] [:upper:]`
+            echo $distribution_type $security
+            stackName=ODFE-$distribution_type-SECURITY-$security
+
+            existingStacks=`aws cloudformation list-stacks --stack-status-filter CREATE_COMPLETE --query 'StackSummaries[*].StackName' --output text`
+
+            for i in $existingStacks
+            do
+                if [[ $i = $stackName ]]
+                then
+                    echo "Stack already exists! Deleting the old stack"
+                    aws cloudformation delete-stack --stack-name $stackName
+                    aws cloudformation wait stack-delete-complete --stack-name $stackName
+                    echo "$stackName deleted successfully!!"
+                fi
+            done
+            
+            .github/scripts/userdata.sh "$distribution_type" "$security"
+            ls -ltr
+
+            # Getting target groups for ELB mapping
+            esTargetGroup=`aws elbv2 describe-target-groups --names ES-$distribution_type-SECURITY-$security --query TargetGroups[*].TargetGroupArn --output text`
+            kibanaTargetGroup=`aws elbv2 describe-target-groups --names KIBANA-$distribution_type-SECURITY-$security --query TargetGroups[*].TargetGroupArn --output text`
+
+            echo "Creating $stackName stack"
+
+            aws cloudformation create-stack --stack-name $stackName \
+            --template-body file://.github/templates/odfe-testing-cluster-static-domain-template.json \
+            --parameters ParameterKey=userdata,ParameterValue=$(base64 -w0 userdata_$distribution_type.sh) \
+            ParameterKey=distribution,ParameterValue=$distribution_type \
+            ParameterKey=security,ParameterValue=$security \
+            ParameterKey=ODFESecurityGroup,ParameterValue=${{secrets.ODFESECURITYGROUP}} \
+            ParameterKey=keypair,ParameterValue=${{secrets.AWS_ODFE_TESTING_CLUSTER_KEYPAIR}} \
+            ParameterKey=esTargetGroup,ParameterValue=$esTargetGroup \
+            ParameterKey=kibanaTargetGroup,ParameterValue=$kibanaTargetGroup
+
+            aws cloudformation wait stack-create-complete --stack-name $stackName
+            sleep 60


### PR DESCRIPTION
Adding workflow and template for static domain testing cluster. The purpose of this PR is to have static domains for testing cluster throughout the release process. The workflow will just register the EC2 to the appropriate target groups and load balancers.

The ELBs and Target groups have already been added in the AWS account. Will add the ELB links in the quip for plugin teams to refer

[Tested](https://github.com/gaiksaya/opendistro-build/runs/809776285?check_suite_focus=true)