### PR TITLE
Fix the kibana startup issue with temp solution

### DIFF
--- a/kibana/docker/templates/Dockerfile.j2
+++ b/kibana/docker/templates/Dockerfile.j2
@@ -38,6 +38,7 @@ RUN curl -Ls {{ kibana_url }}/{{ tarball }} | tar --strip-components=1 -zxf - &&
     for plugin in `cat /tmp/plugins/plugins_kibana.list`; do \
         kibana-plugin install --allow-root file:/tmp/plugins/$plugin ; \
     done && \
+    cp -r /usr/share/kibana/plugins/opendistro_security/node_modules/brace/* /usr/share/kibana/node_modules/brace/ &&\
     rm -rf /tmp/plugins/ && \
     ln -s /usr/share/kibana /opt/kibana && \
     chown -R 1000:0 . && \

--- a/kibana/docker/templates/Dockerfile.j2
+++ b/kibana/docker/templates/Dockerfile.j2
@@ -38,8 +38,8 @@ RUN curl -Ls {{ kibana_url }}/{{ tarball }} | tar --strip-components=1 -zxf - &&
     for plugin in `cat /tmp/plugins/plugins_kibana.list`; do \
         kibana-plugin install --allow-root file:/tmp/plugins/$plugin ; \
     done && \
-    echo "Temp solution to fix the kibana startup issue" &&\
-    cp -r /usr/share/kibana/plugins/opendistro_security/node_modules/brace/* /usr/share/kibana/node_modules/brace/ &&\
+    echo "Temp solution to fix the kibana startup issue" && \
+    cp -r /usr/share/kibana/plugins/opendistro_security/node_modules/brace/* /usr/share/kibana/node_modules/brace/ && \
     rm -rf /tmp/plugins/ && \
     ln -s /usr/share/kibana /opt/kibana && \
     chown -R 1000:0 . && \

--- a/kibana/docker/templates/Dockerfile.j2
+++ b/kibana/docker/templates/Dockerfile.j2
@@ -38,6 +38,7 @@ RUN curl -Ls {{ kibana_url }}/{{ tarball }} | tar --strip-components=1 -zxf - &&
     for plugin in `cat /tmp/plugins/plugins_kibana.list`; do \
         kibana-plugin install --allow-root file:/tmp/plugins/$plugin ; \
     done && \
+    echo "Temp solution to fix the kibana startup issue" &&\
     cp -r /usr/share/kibana/plugins/opendistro_security/node_modules/brace/* /usr/share/kibana/node_modules/brace/ &&\
     rm -rf /tmp/plugins/ && \
     ln -s /usr/share/kibana /opt/kibana && \

--- a/kibana/linux_distributions/opendistro-kibana-build.sh
+++ b/kibana/linux_distributions/opendistro-kibana-build.sh
@@ -72,6 +72,8 @@ do
   $PACKAGE_NAME/bin/kibana-plugin --allow-root install "${ARTIFACTS_URL}/${plugin_latest}"
 done
 
+cp -r $PACKAGE_NAME/plugins/opendistro_security/node_modules/brace/* $PACKAGE_NAME/node_modules/brace/
+
 # List Plugins
 echo "List available plugins"
 ls -lrt $basedir

--- a/kibana/linux_distributions/opendistro-kibana-build.sh
+++ b/kibana/linux_distributions/opendistro-kibana-build.sh
@@ -72,6 +72,7 @@ do
   $PACKAGE_NAME/bin/kibana-plugin --allow-root install "${ARTIFACTS_URL}/${plugin_latest}"
 done
 
+# Temp solution to fix the service startup issue
 cp -r $PACKAGE_NAME/plugins/opendistro_security/node_modules/brace/* $PACKAGE_NAME/node_modules/brace/
 
 # List Plugins


### PR DESCRIPTION
This is a temp solution to fix the kibana startup issue:
the "injex.js" file is missing in the brace node module of kibana 7.8.0 OSS, but opendistro kibana plugins need it.

This project is developed under a test-driven workflow, so please refrain from submitting patches without test coverage. If you are not familiar with testing in Python, please raise an issue instead.
