### PR TITLE
Add support for shipping performance analyzer with RCA

### DIFF
--- a/elasticsearch/docker/build/elasticsearch/bin/docker-entrypoint.sh
+++ b/elasticsearch/docker/build/elasticsearch/bin/docker-entrypoint.sh
@@ -91,7 +91,7 @@ fi
 if [[ -d "/usr/share/elasticsearch/plugins/opendistro_performance_analyzer" ]]; then
     CLK_TCK=`/usr/bin/getconf CLK_TCK`
     ES_JAVA_OPTS="-Dclk.tck=$CLK_TCK -Djdk.attach.allowAttachSelf=true $ES_JAVA_OPTS"
-    if [[ -d "/usr/share/elasticsearhc/performance-analyzer-rca" ]]; then
+    if [[ -d "/usr/share/elasticsearch/performance-analyzer-rca" ]]; then
         ES_JAVA_OPTS="-Djava.security.policy=file:///usr/share/elasticsearch/performance-analyzer-rca/pa_config/es_security.policy $ES_JAVA_OPTS"
         /usr/bin/supervisord -c /usr/share/elasticsearch/performance-analyzer-rca/pa_config/supervisord.conf
     else

--- a/elasticsearch/docker/build/elasticsearch/bin/docker-entrypoint.sh
+++ b/elasticsearch/docker/build/elasticsearch/bin/docker-entrypoint.sh
@@ -90,8 +90,14 @@ fi
 
 if [[ -d "/usr/share/elasticsearch/plugins/opendistro_performance_analyzer" ]]; then
     CLK_TCK=`/usr/bin/getconf CLK_TCK`
-    ES_JAVA_OPTS="-Djava.security.policy=file:///usr/share/elasticsearch/plugins/opendistro_performance_analyzer/pa_config/es_security.policy -Dclk.tck=$CLK_TCK -Djdk.attach.allowAttachSelf=true $ES_JAVA_OPTS"
-    /usr/bin/supervisord -c /usr/share/elasticsearch/plugins/opendistro_performance_analyzer/pa_config/supervisord.conf
+    ES_JAVA_OPTS="-Dclk.tck=$CLK_TCK -Djdk.attach.allowAttachSelf=true $ES_JAVA_OPTS"
+    if [[ -d "/usr/share/elasticsearhc/performance-analyzer-rca" ]]; then
+        ES_JAVA_OPTS="-Djava.security.policy=file:///usr/share/elasticsearch/performance-analyzer-rca/pa_config/es_security.policy $ES_JAVA_OPTS"
+        /usr/bin/supervisord -c /usr/share/elasticsearch/performance-analyzer-rca/pa_config/supervisord.conf
+    else
+        ES_JAVA_OPTS="-Djava.security.policy=file:///usr/share/elasticsearch/plugins/opendistro_performance_analyzer/pa_config/es_security.policy $ES_JAVA_OPTS"
+        /usr/bin/supervisord -c /usr/share/elasticsearch/plugins/opendistro_performance_analyzer/pa_config/supervisord.conf
+    fi
 fi
 
 run_as_other_user_if_needed /usr/share/elasticsearch/bin/elasticsearch "${es_opts[@]}"

--- a/elasticsearch/docker/templates/Dockerfile.j2
+++ b/elasticsearch/docker/templates/Dockerfile.j2
@@ -108,8 +108,10 @@ RUN for plugin_path in `cat /tmp/plugins/plugins.list`; do \
       elasticsearch-plugin install --batch file:/tmp/plugins/$plugin_path; \
     done
 
-# Pull performance analyzer agent(RCA) from the plugin directory out into ESHOME
-RUN if [ -d plugins/opendistro_performance_analyzer/performance-analyzer-rca ]; then mv plugins/opendistro_performance_analyzer/performance-analyzer-rca ./; fi
+# Pull performance analyzer agent(RCA) from the plugin directory out into ESHOME and make the agent executable.
+RUN if [ -d plugins/opendistro_performance_analyzer/performance-analyzer-rca ]; then \
+     mv plugins/opendistro_performance_analyzer/performance-analyzer-rca ./ && \
+     chmod 755 performance-analyzer-rca/pa_bin/performance-analyzer-agent; fi
 # Make the certificate installer script executable. This script has to be executed before ES is started.
 RUN security=`ls /tmp/plugins/|grep opendistro_security|wc -l` && \
     if [ $security -gt 0 ]; then chmod +x /usr/share/elasticsearch/plugins/opendistro_security/tools/install_demo_configuration.sh; \

--- a/elasticsearch/docker/templates/Dockerfile.j2
+++ b/elasticsearch/docker/templates/Dockerfile.j2
@@ -108,6 +108,8 @@ RUN for plugin_path in `cat /tmp/plugins/plugins.list`; do \
       elasticsearch-plugin install --batch file:/tmp/plugins/$plugin_path; \
     done
 
+# Pull performance analyzer agent(RCA) from the plugin directory out into ESHOME
+RUN if [ -d plugins/opendistro_performance_analyzer/performance-analyzer-rca ]; then mv plugins/opendistro_performance_analyzer/performance-analyzer-rca ./; fi
 # Make the certificate installer script executable. This script has to be executed before ES is started.
 RUN security=`ls /tmp/plugins/|grep opendistro_security|wc -l` && \
     if [ $security -gt 0 ]; then chmod +x /usr/share/elasticsearch/plugins/opendistro_security/tools/install_demo_configuration.sh; \
@@ -191,7 +193,7 @@ RUN chgrp 0 /usr/local/bin/docker-entrypoint.sh && \
     chmod g=u /etc/passwd && \
     chmod 0775 /usr/local/bin/docker-entrypoint.sh
 
-EXPOSE 9200 9300 9600
+EXPOSE 9200 9300 9600 9650
 
 LABEL org.label-schema.schema-version="1.0" \
   org.label-schema.name="opendistroforelasticsearch" \


### PR DESCRIPTION
This small change adds support for packaging performance analyzer + RCA in ODFE.

Summary of changes:
* Separates the agent from the plugin location after install as the agent(with RCA) and the plugin are bundled together.
* Updates path to PA's conf files in docker entrypoint.