### PR TITLE
make windows workflow use python to eval version-info

### DIFF
--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -80,7 +80,7 @@ jobs:
           pip3 install awscli
           dir
           $PACKAGE="opendistroforelasticsearch"
-          $OD_VERSION=$(./bin/version-info --od)
+          $OD_VERSION=$(python ./bin/version-info --od)
           $S3_PACKAGE="odfe-"+$OD_VERSION+".zip"
           dir
           echo downloading zip from S3 
@@ -134,7 +134,7 @@ jobs:
           echo pip3 -version
           pip3 install awscli
           $PACKAGE="opendistroforelasticsearch"
-          $OD_VERSION=$(./bin/version-info --od)
+          $OD_VERSION=$(python ./bin/version-info --od)
           $S3_PACKAGE="odfe-"+$OD_VERSION+".zip"
           dir
           echo downloading zip from S3 


### PR DESCRIPTION
This PR is to make windows workflow use python to eval version-info, since windows does not work with env utility like on *nix systems.

### Test Cases: ###
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/151886922