### PR TITLE
Tweak docker with correct ISM integTest setups

### DIFF
--- a/.github/workflows/test-build-docker.yml
+++ b/.github/workflows/test-build-docker.yml
@@ -89,6 +89,7 @@ jobs:
         docker login --username $DOCKER_USER --password $DOCKER_PASS
         docker images|grep "amazon/opendistro-for-elasticsearch" > docker_id.out
         image_id=`awk -F ' ' '{print $3}' docker_id.out`
+        DOCKER_NAME=odfe-test-$ODFE_VER
         echo "Docker Id is $image_id"
         docker tag $image_id opendistroforelasticsearch/opendistroforelasticsearch:$ODFE_VER
         docker images
@@ -106,10 +107,10 @@ jobs:
            docker build -t odfe-http:no-security .
            sleep 5
      
-           docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" odfe-http:no-security
+           docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" --name $DOCKER_NAME odfe-http:no-security
         else
            echo "Running originially created docker image"
-           docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" opendistroforelasticsearch/opendistroforelasticsearch:$ODFE_VER
+           docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" --name $DOCKER_NAME opendistroforelasticsearch/opendistroforelasticsearch:$ODFE_VER
         fi
     
     - name: Create Email Message
@@ -135,8 +136,13 @@ jobs:
     - name: Test ISM Plugin
       if: always()
       run: |
+        ODFE_VER=`./bin/version-info --od`
+        DOCKER_NAME=odfe-test-$ODFE_VER
+        docker exec -t $DOCKER_NAME /bin/bash -c "echo ''  >> /usr/share/elasticsearch/config/elasticsearch.yml"
+        docker exec -t $DOCKER_NAME /bin/bash -c "echo path.repo: [\"/usr/share/elasticsearch\"] >> /usr/share/elasticsearch/config/elasticsearch.yml"
+        docker restart $DOCKER_NAME
         cd ..
-        sleep 15
+        sleep 30
         curl -XGET http://localhost:9200/_cat/plugins > plugins.out
         
         if cat plugins.out|grep opendistro_index_management


### PR DESCRIPTION
This PR is to tweak docker with correct ISM integTest setups, with path.repo set for snapshots during integTest process.

### Test Cases: ###
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/153070674