### PR TITLE
Remove old bin path for version-info scripts

### DIFF
--- a/.github/workflows/release-sync-ami.yml
+++ b/.github/workflows/release-sync-ami.yml
@@ -19,7 +19,6 @@ jobs:
 
       - name: Getting OD version
         run: |
-          cd elasticsearch/bin
           OD_VERSION=`./bin/version-info --od`
           echo "::set-env name=od_version::$OD_VERSION"
     

--- a/.github/workflows/test-build-ami.yml
+++ b/.github/workflows/test-build-ami.yml
@@ -26,7 +26,6 @@ jobs:
         #!/bin/bash
         export APT_OSS_version=`./bin/version-info --es`
         OD_version=`./bin/version-info --od`
-        cd elasticsearch/bin
         export region_name="us-east-1"
         export os="amazonLinux"
         export security_group_id="sg-0ffdd3b008cfb0b63"


### PR DESCRIPTION
This PR is to remove old bin path for version-info scripts.
