### PR TITLE
fix: apply custom ingress labels

### DIFF
--- a/helm/opendistro-es/templates/kibana/kibana-ingress.yml
+++ b/helm/opendistro-es/templates/kibana/kibana-ingress.yml
@@ -20,6 +20,9 @@ kind: Ingress
 metadata:
   labels:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
+  {{- range $key, $value := .Values.kibana.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
   name: {{ template "opendistro-es.fullname" . }}-kibana
   annotations:
     {{- range $key, $value := .Values.kibana.ingress.annotations }}


### PR DESCRIPTION
According to the README of the helm chart there is the option to specify additional kibana ingress labels with `kibana.ingress.labels`. Unfortunately this option doesn't do anything.
This patch adds the required code to the template.
A similar patch might also be required for `elasticsearch.client.ingress.labels` but I can't test this because I only use kibana.
