### PR TITLE
make kibana label/selector unique

### DIFF
--- a/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
@@ -19,19 +19,19 @@ kind: Deployment
 metadata:
   labels:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
-    role: kibana
+    role: {{ .Values.global.clusterName }}-kibana
   name: {{ template "opendistro-es.fullname" . }}-kibana
 spec:
   replicas: {{ .Values.kibana.replicas }}
   selector:
     matchLabels:
 {{ include "opendistro-es.labels.selector" . | indent 6 }}
-      role: kibana
+      role: {{ .Values.global.clusterName }}-kibana
   template:
     metadata:
       labels:
 {{ include "opendistro-es.labels.standard" . | indent 8 }}
-        role: kibana
+        role: {{ .Values.global.clusterName }}-kibana
       annotations:
         {{/* This forces a restart if the secret config has changed */}}
         {{- if .Values.kibana.config }}

--- a/helm/opendistro-es/templates/kibana/kibana-service.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-service.yaml
@@ -21,7 +21,7 @@ metadata:
 {{ toYaml .Values.kibana.service.annotations | indent 4 }}
   labels:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
-    role: kibana
+    role: {{ .Values.global.clusterName }}-kibana
   name: {{ template "opendistro-es.fullname" . }}-kibana-svc
 spec:
   ports:
@@ -29,6 +29,6 @@ spec:
     port: {{ .Values.kibana.externalPort }}
     targetPort: {{ .Values.kibana.port }}
   selector:
-    role: kibana
+    role: {{ .Values.global.clusterName }}-kibana
   type: {{ .Values.kibana.service.type }}
 {{- end }}


### PR DESCRIPTION
Improvement: multiple kibana instances in the same namespace

Currently, in the helm template for kibana there's a hard coded label and selector `role: kibana`
in the service and deployment.
The issue:
If I run 2 different kibana instances in the same namespace but pointing to different clusters then the helm chart
would create 2 kibana-svc but the backend would contain all kibana instances (because of same label/selector).
So kubernetes would spread my request over all the different kibana instances. 
The fix:
I added the .global.clusterName to the label/selector which makes them unique and therefore don't interfere.
It could be basically anything as long as it's unique.
I keep kibana and elasticsearch separate but all kibana instances are in one namespace.