### PR TITLE
Move PA/RCA files to subdir owned by elasticsearch user (Support)

### DIFF
--- a/elasticsearch/docker/templates/Dockerfile.j2
+++ b/elasticsearch/docker/templates/Dockerfile.j2
@@ -179,7 +179,8 @@ RUN mkdir /usr/share/elasticsearch && \
     chmod 0775 /usr/share/elasticsearch && \
     chgrp 0 /usr/share/elasticsearch
 
-RUN mkdir /usr/share/supervisor
+RUN mkdir -p /usr/share/supervisor/performance_analyzer/ && \
+    chown 1000 /usr/share/supervisor/performance_analyzer
 
 WORKDIR /usr/share/elasticsearch
 COPY --from=prep_es_files --chown=1000:0 /usr/share/elasticsearch /usr/share/elasticsearch


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/opendistro-build/issues/34
https://github.com/opendistro-for-elasticsearch/performance-analyzer/pull/146
https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/pull/271

*Description of changes:*
 Move PA/RCA files to subdir owned by elasticsearch user (Support)

*Tests:*
[image](https://user-images.githubusercontent.com/65193828/87365444-3d975f80-c544-11ea-8ad0-4a2d4d81320a.png)

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
