### PR TITLE
removed clusterIP: None

### DIFF
--- a/helm/opendistro-es/templates/elasticsearch/es-data-svc.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-svc.yaml
@@ -32,7 +32,6 @@ spec:
     name: metrics
   - port: 9650
     name: rca
-  clusterIP: None
   selector:
     role: data
 {{- end }}

--- a/helm/opendistro-es/templates/elasticsearch/master-svc.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/master-svc.yaml
@@ -26,7 +26,6 @@ spec:
   ports:
     - port: 9300
       protocol: TCP
-  clusterIP: None
   selector:
     role: master
 {{- end }}


### PR DESCRIPTION
There was never any follow up as to why `clusterIP: None` was necessary for the services in the helm charts on the GitHub Issue https://github.com/opendistro-for-elasticsearch/opendistro-build/issues/52  and it was closed prematurely I feel.

The PR removes this as it fails with Helm v3.

`kubectl version`
>Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.5", GitCommit:"e6503f8d8f769ace2f338794c914a96fc335df0f", GitTreeState:"clean", BuildDate:"2020-06-27T00:38:11Z", GoVersion:"go1.14.4", Compiler:"gc", Platform:"darwin/amd64"}
>Server Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.2", GitCommit:"c02cd11cc8bced1391937fe271c3b9c9fe9befa0", GitTreeState:"clean", BuildDate:"2020-06-24T19:57:20Z", GoVersion:"go1.13.6", Compiler:"gc", Platform:"linux/amd64"}`

`helm version`
> version.BuildInfo{Version:"v3.2.1", GitCommit:"fe51cd1e31e6a202cba7dead9552a6d418ded79a", GitTreeState:"clean", GoVersion:"go1.13.10"}
