### PR TITLE
Replace ubuntu-latest with ubuntu-18.04 tags now

### DIFF
--- a/.github/workflows/check-plugin.yml
+++ b/.github/workflows/check-plugin.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   plugin-availability-main:
     name: Check Plugin Availability Main
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - name: Configure AWS Credentials

--- a/.github/workflows/check-version-upgrade.yml
+++ b/.github/workflows/check-version-upgrade.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     Provision-Runners-RPM:
       name: Provision-Runners-RPM
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-18.04
       steps:
         - uses: actions/checkout@v1
         - name: Configure AWS Credentials
@@ -24,7 +24,7 @@ jobs:
 
     Test-DEB:
       name: Test DEB upgrade
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-18.04
       steps:
         - uses: actions/checkout@v2
         - name: Setup Java
@@ -119,7 +119,7 @@ jobs:
       needs: [Test-RPM]
       if: always()
       name: CleanUp-Runners-RPM
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-18.04
       steps:
         - uses: actions/checkout@v1
         - name: Configure AWS Credentials

--- a/.github/workflows/prod-sync-ami.yml
+++ b/.github/workflows/prod-sync-ami.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   Sync-AMI-Prod:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/prod-sync-deb.yml
+++ b/.github/workflows/prod-sync-deb.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   Sync-Deb-Prod:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     container: 
       image: opendistroforelasticsearch/base-ubuntu
     name: Sync Deb Artifacts to Prod

--- a/.github/workflows/prod-sync-tar.yml
+++ b/.github/workflows/prod-sync-tar.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   Sync-Tarball-Prod:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/prod-sync-windows.yml
+++ b/.github/workflows/prod-sync-windows.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   Sync-Windows-Prod:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/staging-build-ami.yml
+++ b/.github/workflows/staging-build-ami.yml
@@ -6,7 +6,7 @@ on:
     
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8

--- a/.github/workflows/staging-build-deb.yml
+++ b/.github/workflows/staging-build-deb.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   plugin-availability:
     name: Check Plugin Availability
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - name: Configure AWS Credentials
@@ -25,7 +25,7 @@ jobs:
   build-es-artifacts:
     needs: [plugin-availability]
     name: Build ES Artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     container:
       image: opendistroforelasticsearch/multijava08101112-git:v1
     steps:
@@ -55,7 +55,7 @@ jobs:
   build-kibana-artifacts:
     needs: [plugin-availability]
     name: Build Kibana Artifacts
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     container:
       image: opendistroforelasticsearch/jsenv:v1
     steps:
@@ -71,7 +71,7 @@ jobs:
 
   sign-deb-artifacts:
     needs: [build-es-artifacts, build-kibana-artifacts]
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     container:
       image: opendistroforelasticsearch/base-ubuntu
     steps:
@@ -124,7 +124,7 @@ jobs:
 
   Build-ES-and-Kibana-Ubuntu-Docker:
     needs: [sign-deb-artifacts]
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     name: Build ubuntu image for Sanity Testing
     steps:
       - uses: actions/checkout@v1
@@ -181,7 +181,7 @@ jobs:
 
   Test-ISM-NoSec:
     needs: [sign-deb-artifacts]
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     name: Test-ISM-NoSec
     strategy:
       matrix:
@@ -211,7 +211,7 @@ jobs:
 
   Test-ALERTING-NoSec:
     needs: [sign-deb-artifacts]
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     name: Test-ALERTING-NoSec
     strategy:
       matrix:
@@ -240,7 +240,7 @@ jobs:
           
   Test-SQL-NoSec:
     needs: [sign-deb-artifacts]
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     name: Test-SQL-NoSec
     strategy:
       matrix:
@@ -269,7 +269,7 @@ jobs:
   
   Test-KNN-NoSec:
     needs: [sign-deb-artifacts]
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     name: Test-KNN-NoSec
     strategy:
       matrix:
@@ -294,7 +294,7 @@ jobs:
    
   Test-AD-NoSec:
     needs: [sign-deb-artifacts]
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     name: Test-AD-NoSec
     strategy:
       matrix:
@@ -323,7 +323,7 @@ jobs:
           
   Test-SQL:
     needs: [sign-deb-artifacts]
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     name: Test-SQL
     strategy:
       matrix:
@@ -352,7 +352,7 @@ jobs:
           
   Test-AD:
     needs: [sign-deb-artifacts]
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     name: Test-AD
     strategy:
       matrix:
@@ -382,7 +382,7 @@ jobs:
           
   Test-AD-KIBANA-NoSec:
     needs: [sign-deb-artifacts]
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     name: Test-AD-KIBANA-NoSec
     strategy:
       matrix:

--- a/.github/workflows/staging-build-docker-ci.yml
+++ b/.github/workflows/staging-build-docker-ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         java: [14]
     name: Build ES Docker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
 

--- a/.github/workflows/staging-build-docker.yml
+++ b/.github/workflows/staging-build-docker.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         java: [14]
     name: Build ES Docker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
        
@@ -145,7 +145,7 @@ jobs:
   
   Test-ISM-NoSec:
     needs: [build-es-docker]
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     name: Test-ISM-NoSec
     strategy:
       matrix:
@@ -175,7 +175,7 @@ jobs:
 
   Test-ALERTING-NoSec:
     needs: [build-es-docker]
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     name: Test-ALERTING-NoSec
     strategy:
       matrix:
@@ -204,7 +204,7 @@ jobs:
           
   Test-SQL-NoSec:
     needs: [build-es-docker]
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     name: Test-SQL-NoSec
     strategy:
       matrix:
@@ -233,7 +233,7 @@ jobs:
   
   Test-KNN-NoSec:
     needs: [build-es-docker]
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     name: Test-KNN-NoSec
     strategy:
       matrix:
@@ -258,7 +258,7 @@ jobs:
    
   Test-AD-NoSec:
     needs: [build-es-docker]
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     name: Test-AD-NoSec
     strategy:
       matrix:
@@ -287,7 +287,7 @@ jobs:
 
   Test-SQL:
     needs: [build-es-docker]
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     name: Test-SQL
     strategy:
       matrix:
@@ -316,7 +316,7 @@ jobs:
 
   Test-AD:
     needs: [build-es-docker]
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     name: Test-AD
     strategy:
       matrix:

--- a/.github/workflows/staging-build-rpm.yml
+++ b/.github/workflows/staging-build-rpm.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   plugin-availability:
     name: Check Plugin Availability
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - name: Configure AWS Credentials
@@ -25,7 +25,7 @@ jobs:
   build-es-artifacts:
     needs: [plugin-availability]
     name: Build ES Artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     container:
       image: opendistroforelasticsearch/multijava08101112-git:v1
 
@@ -57,7 +57,7 @@ jobs:
   build-kibana-artifacts:
     needs: [plugin-availability]
     name: Build Kibana Artifacts
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     container:
       image: opendistroforelasticsearch/jsenv:v1
     steps:
@@ -102,7 +102,7 @@ jobs:
 
   Build-ES-and-Kibana-Centos-Docker:
     needs: [signing-artifacts]
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     name: Build Centos image for Sanity Testing
     steps:
       - uses: actions/checkout@v1
@@ -160,7 +160,7 @@ jobs:
   Provision-Runners:
     needs: [signing-artifacts]
     name: Provision-Runners
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - name: Configure AWS Credentials
@@ -402,7 +402,7 @@ jobs:
     needs: [Test-SQL, Test-AD, Test-ISM-NoSec, Test-ALERTING-NoSec, Test-SQL-NoSec, Test-KNN-NoSec, Test-AD-NoSec, Test-AD-KIBANA-NoSec]
     if: always()
     name: CleanUp-Runners
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - name: Configure AWS Credentials

--- a/.github/workflows/staging-build-tar.yml
+++ b/.github/workflows/staging-build-tar.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   plugin-availability:
     name: Check Plugin Availability
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - name: Configure AWS Credentials
@@ -25,7 +25,7 @@ jobs:
   build-es-artifacts:
     needs: [plugin-availability]
     name: Build ES Artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     container:
       image: opendistroforelasticsearch/multijava08101112-git:v1
     steps:
@@ -43,7 +43,7 @@ jobs:
   build-kibana-artifacts:
     needs: [plugin-availability]
     name: Build Kibana Artifacts
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     container:
         image: opendistroforelasticsearch/jsenv:v1
     steps:
@@ -59,7 +59,7 @@ jobs:
 
   Test-ISM-NoSec:
     needs: [build-es-artifacts]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     name: Test-ISM-NoSec
     strategy:
       matrix:
@@ -91,7 +91,7 @@ jobs:
 
   Test-Alerting-NoSec:
     needs: [build-es-artifacts]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     name: Test-Alerting-NoSec
     strategy:
       matrix:
@@ -123,7 +123,7 @@ jobs:
 
   Test-SQL-NoSec:
     needs: [build-es-artifacts]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     name: Test-SQL-NoSec
     strategy:
       matrix:
@@ -155,7 +155,7 @@ jobs:
           
   Test-KNN-NoSec:
     needs: [build-es-artifacts]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     name: Test-KNN-NoSec
     strategy:
       matrix:
@@ -187,7 +187,7 @@ jobs:
           
   Test-AD-NoSec:
     needs: [build-es-artifacts]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     name: Test-AD-NoSec
     strategy:
       matrix:
@@ -219,7 +219,7 @@ jobs:
           
   Test-SQL:
     needs: [build-es-artifacts]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     name: Test-SQL
     strategy:
       matrix:
@@ -251,7 +251,7 @@ jobs:
   
   Test-AD:
     needs: [build-es-artifacts]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     name: Test-AD
     strategy:
       matrix:

--- a/.github/workflows/staging-build-windows.yml
+++ b/.github/workflows/staging-build-windows.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-es-artifacts:
     name: Build Windows ES Artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
 
@@ -30,7 +30,7 @@ jobs:
         
   build-kibana-artifacts:
     name: Build Kibana Artifacts
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     steps:
     - uses: actions/checkout@v1
     - name: Configure AWS Credentials

--- a/.github/workflows/test-cluster-delete.yml
+++ b/.github/workflows/test-cluster-delete.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   Create-Cluster:
     name: Delete Testing cluster
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/test-cluster-set-up.yml
+++ b/.github/workflows/test-cluster-set-up.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   Create-Cluster:
     name: Create Testing cluster
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/test-cluster-static-domain-set-up.yml
+++ b/.github/workflows/test-cluster-static-domain-set-up.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   Create-Cluster:
     name: Create Testing cluster
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
This PR is to replace ubuntu-latest with ubuntu-18.04 tags now.

