### PR TITLE
ODFE Final Plugin Version Cut in versions.json and plugins.json

### DIFF
--- a/bin/plugins-info
+++ b/bin/plugins-info
@@ -8,13 +8,15 @@
 # About:         Print the ES/KIBANA plugin names and git urls with correct dependency orders
 #                as defined in the 'plugins.json' file
 #
-# Usage:         ./plugins-info $PLUGINS_TYPE [$RETURN_TYPE] [$GITHUB_TOKEN_PAT]
-#                $PLUGINS_TYPE: <check plugins.json> (required)
-#                $RETURN_TYPE: <default to name> | --git (optional)
-#                $GITHUB_TOKEN_PAT: GitHub Personal Access Token for API Calls Here (optional)
+# Usage:         ./plugins-info $PLUGINS_TYPE $RETURN_TYPE [$REQUIRE_INSTALL]
+#                $PLUGINS_TYPE: elasticsearch | kibana | client | perf-top  (required)
+#                $RETURN_TYPE: zip | deb | rpm | windows | git | cutversion (required)
+#                $REQUIRE_INSTALL: <default to both> (optional)
+#                                  --require-install-true
+#                                  --require-install-false
 #
 # Starting Date: 2020-06-24
-# Modified Date: 2020-08-07
+# Modified Date: 2020-08-27
 ###############################################################################################
 
 set -e
@@ -22,25 +24,23 @@ ROOT=`dirname $(realpath $0)`;
 PLUGINS_LIST="$ROOT/plugins.json"
 PLUGINS_TYPE=`echo $1 | tr '[:upper:]' '[:lower:]'`
 RETURN_TYPE=`echo $2 | tr '[:upper:]' '[:lower:]'`
-GITHUB_TOKEN_PAT=$3
+REQUIRE_INSTALL=`echo $3 | tr '[:upper:]' '[:lower:]'`
 
-if [ -z "$PLUGINS_TYPE" ]
+if [ -z "$PLUGINS_TYPE" ] || [ -z "$RETURN_TYPE" ]
 then
-  echo "Please enter \$PLUGINS_TYPE [\$RETURN_TYPE] as parameter(s)"
-  echo "Example: \"$0 rpm\" (Retrieve S3 Paths)"
-  echo "Example: \"$0 rpm --s3\" (Retrieve S3 Paths)"
-  echo "Example: \"$0 rpm --git\" (Retrieve Git URLs)"
+  echo "Please enter \$PLUGINS_TYPE \$RETURN_TYPE [\$REQUIRE_INSTALL] as parameter(s)"
+  echo "Example: \"$0 elasticsearch zip\" (Retrieve all es plugins s3 paths for zip formats)"
+  echo "Example: \"$0 elasticsearch zip --require-install-true\" (Retrieve es plugins s3 paths for zip formats that requires installation)"
+  echo "Example: \"$0 elasticsearch zip --require-install-false\" (Retrieve es plugins s3 paths for zip formats that DO NOT requires installation)"
   exit 1
 fi
 
-if [ "$RETURN_TYPE" = "--git" ]
+if [ "$REQUIRE_INSTALL" = "--require-install-true" ]
 then
-  jq -r ".${PLUGINS_TYPE}[].git" "${PLUGINS_LIST}"
-
-elif [ -z "$RETURN_TYPE" ] || [ "$RETURN_TYPE" = "--s3" ]
+    jq -r ".[] | select(.category == \"${PLUGINS_TYPE}\") | select(.require_install == \"true\") |  .$RETURN_TYPE" $PLUGINS_LIST
+elif [ "$REQUIRE_INSTALL" = "--require-install-false" ]
 then
-  jq -r ".${PLUGINS_TYPE}[].s3" "${PLUGINS_LIST}"
-
+    jq -r ".[] | select(.category == \"${PLUGINS_TYPE}\") | select(.require_install == \"false\") |  .$RETURN_TYPE" $PLUGINS_LIST
+else
+    jq -r ".[] | select(.category == \"${PLUGINS_TYPE}\") |  .$RETURN_TYPE" $PLUGINS_LIST
 fi
-
-

--- a/bin/plugins.json
+++ b/bin/plugins.json
@@ -1,188 +1,203 @@
 {
-  "zip":[
-    {
-      "s3":"opendistro-sql/opendistro_sql",
-      "git":"opendistro-for-elasticsearch/sql"
-    },
-    {
-      "s3":"opendistro-alerting/opendistro_alerting",
-      "git":"opendistro-for-elasticsearch/alerting"
-    },
-    {
-      "s3":"opendistro-job-scheduler/opendistro-job-scheduler",
-      "git":"opendistro-for-elasticsearch/job-scheduler"
-    },
-    {
-      "s3":"opendistro-security/opendistro_security",
-      "git":"opendistro-for-elasticsearch/security"
-    },
-    {
-      "s3":"performance-analyzer/opendistro_performance_analyzer",
-      "git":"opendistro-for-elasticsearch/performance-analyzer"
-    },
-    {
-      "s3":"opendistro-index-management/opendistro_index_management",
-      "git":"opendistro-for-elasticsearch/index-management"
-    },
-    {
-      "s3":"opendistro-knn/opendistro-knn",
-      "git":"opendistro-for-elasticsearch/k-NN"
-    },
-    {
-      "s3":"opendistro-anomaly-detection/opendistro-anomaly-detection",
-      "git":"opendistro-for-elasticsearch/anomaly-detection"
-    }
-  ],
-  "windows":[
-    {
-      "s3":"opendistro-sql/opendistro_sql",
-      "git":"opendistro-for-elasticsearch/sql"
-    },
-    {
-      "s3":"opendistro-alerting/opendistro_alerting",
-      "git":"opendistro-for-elasticsearch/alerting"
-    },
-    {
-      "s3":"opendistro-job-scheduler/opendistro-job-scheduler",
-      "git":"opendistro-for-elasticsearch/job-scheduler"
-    },
-    {
-      "s3":"opendistro-security/opendistro_security",
-      "git":"opendistro-for-elasticsearch/security"
-    },
-    {
-      "s3":"opendistro-index-management/opendistro_index_management",
-      "git":"opendistro-for-elasticsearch/index-management"
-    },
-    {
-      "s3":"opendistro-anomaly-detection/opendistro-anomaly-detection",
-      "git":"opendistro-for-elasticsearch/anomaly-detection"
-    }
-  ],
-  "rpm":[
-    {
-      "s3":"opendistro-sql/opendistro-sql",
-      "git":"opendistro-for-elasticsearch/sql"
-    },
-    {
-      "s3":"opendistro-alerting/opendistro-alerting",
-      "git":"opendistro-for-elasticsearch/alerting"
-    },
-    {
-      "s3":"opendistro-job-scheduler/opendistro-job-scheduler",
-      "git":"opendistro-for-elasticsearch/job-scheduler"
-    },
-    {
-      "s3":"opendistro-security/opendistro-security",
-      "git":"opendistro-for-elasticsearch/security"
-    },
-    {
-      "s3":"opendistro-performance-analyzer/opendistro-performance-analyzer",
-      "git":"opendistro-for-elasticsearch/performance-analyzer"
-    },
-    {
-      "s3":"opendistro-index-management/opendistro-index-management",
-      "git":"opendistro-for-elasticsearch/index-management"
-    },
-    {
-      "s3":"opendistro-knn/opendistro-knn",
-      "git":"opendistro-for-elasticsearch/k-NN"
-    },
-    {
-      "s3":"opendistro-knnlib/opendistro-knnlib",
-      "git":"opendistro-for-elasticsearch/k-NN"
-    },
-    {
-      "s3":"opendistro-anomaly-detection/opendistro-anomaly-detection",
-      "git":"opendistro-for-elasticsearch/anomaly-detection"
-    }
-  ],
-  "deb":[
-    {
-      "s3":"opendistro-sql/opendistro-sql",
-      "git":"opendistro-for-elasticsearch/sql"
-    },
-    {
-      "s3":"opendistro-alerting/opendistro-alerting",
-      "git":"opendistro-for-elasticsearch/alerting"
-    },
-    {
-      "s3":"opendistro-job-scheduler/opendistro-job-scheduler",
-      "git":"opendistro-for-elasticsearch/job-scheduler"
-    },
-    {
-      "s3":"opendistro-security/opendistro-security",
-      "git":"opendistro-for-elasticsearch/security"
-    },
-    {
-      "s3":"opendistro-performance-analyzer/opendistro-performance-analyzer",
-      "git":"opendistro-for-elasticsearch/performance-analyzer"
-    },
-    {
-      "s3":"opendistro-index-management/opendistro-index-management",
-      "git":"opendistro-for-elasticsearch/index-management"
-    },
-    {
-      "s3":"opendistro-knn/opendistro-knn",
-      "git":"opendistro-for-elasticsearch/k-NN"
-    },
-    {
-      "s3":"opendistro-knnlib/opendistro-knnlib",
-      "git":"opendistro-for-elasticsearch/k-NN"
-    },
-    {
-      "s3":"opendistro-anomaly-detection/opendistro-anomaly-detection",
-      "git":"opendistro-for-elasticsearch/anomaly-detection"
-    }
-  ],
-  "kibana":[
-    {
-      "s3":"opendistro-sql-workbench/opendistro-sql-workbench",
-      "git":"opendistro-for-elasticsearch/sql"
-    },
-    {
-      "s3":"opendistro-anomaly-detection/opendistro-anomaly-detection-kibana",
-      "git":"opendistro-for-elasticsearch/anomaly-detection-kibana-plugin"
-    },
-    {
-      "s3":"opendistro-security/opendistro_security_kibana_plugin",
-      "git":"opendistro-for-elasticsearch/security-kibana-plugin"
-    },
-    {
-      "s3":"opendistro-alerting/opendistro-alerting",
-      "git":"opendistro-for-elasticsearch/alerting-kibana-plugin"
-    },
-    {
-      "s3":"opendistro-index-management/opendistro_index_management_kibana",
-      "git":"opendistro-for-elasticsearch/index-management-kibana-plugin"
-    }
-  ],
-  "clidvr":[
-    {
-      "s3":"opendistro-sql-cli/odfe-sql-cli",
-      "git":"opendistro-for-elasticsearch/sql"
-    },
-    {
-      "s3":"opendistro-sql-jdbc/opendistro-sql-jdbc",
-      "git":"opendistro-for-elasticsearch/sql"
-    },
-    {
-      "s3":"opendistro-sql-odbc/mac/Open Distro for Elasticsearch SQL ODBC Driver 64-bit",
-      "git":"opendistro-for-elasticsearch/sql"
-    },
-    {
-      "s3":"opendistro-sql-odbc/windows/Open Distro for Elasticsearch SQL ODBC Driver 64-bit",
-      "git":"opendistro-for-elasticsearch/sql"
-    },
-    {
-      "s3":"opendistro-sql-odbc/windows/Open Distro for Elasticsearch SQL ODBC Driver 32-bit",
-      "git":"opendistro-for-elasticsearch/sql"
-    }
-  ],
-  "perftop":[
-    {
-      "s3":"perf-top",
-      "git":"opendistro-for-elasticsearch/perftop"
-    }
-  ]
+  "sql": {
+    "git": "opendistro-for-elasticsearch/sql",
+    "zip": "opendistro-sql/opendistro_sql",
+    "deb": "opendistro-sql/opendistro-sql",
+    "rpm": "opendistro-sql/opendistro-sql",
+    "windows": "opendistro-sql/opendistro_sql",
+    "cutversion": "1.9.0.0",
+    "require_install": "true",
+    "category": "elasticsearch"
+  },
+  "alerting": {
+    "git": "opendistro-for-elasticsearch/alerting",
+    "zip": "opendistro-alerting/opendistro_alerting",
+    "deb": "opendistro-alerting/opendistro-alerting",
+    "rpm": "opendistro-alerting/opendistro-alerting",
+    "windows": "opendistro-alerting/opendistro_alerting",
+    "cutversion": "1.9.0.0",
+    "require_install": "true",
+    "category": "elasticsearch"
+  },
+  "job-scheduler": {
+    "git": "opendistro-for-elasticsearch/job-scheduler",
+    "zip": "opendistro-job-scheduler/opendistro-job-scheduler",
+    "deb": "opendistro-job-scheduler/opendistro-job-scheduler",
+    "rpm": "opendistro-job-scheduler/opendistro-job-scheduler",
+    "windows": "opendistro-job-scheduler/opendistro-job-scheduler",
+    "cutversion": "1.9.0.0",
+    "require_install": "true",
+    "category": "elasticsearch"
+  },
+  "security": {
+    "git": "opendistro-for-elasticsearch/security",
+    "zip": "opendistro-security/opendistro_security",
+    "deb": "opendistro-security/opendistro-security",
+    "rpm": "opendistro-security/opendistro-security",
+    "windows": "opendistro-security/opendistro_security",
+    "cutversion": "1.9.0.0",
+    "require_install": "true",
+    "category": "elasticsearch"
+  },
+  "performance-analyzer": {
+    "git": "opendistro-for-elasticsearch/performance-analyzer",
+    "zip": "performance-analyzer/opendistro_performance_analyzer",
+    "deb": "opendistro-performance-analyzer/opendistro-performance-analyzer",
+    "rpm": "opendistro-performance-analyzer/opendistro-performance-analyzer",
+    "windows": "none",
+    "cutversion": "1.9.0.1",
+    "require_install": "true",
+    "category": "elasticsearch"
+  },
+  "index-management": {
+    "git": "opendistro-for-elasticsearch/index-management",
+    "zip": "opendistro-index-management/opendistro_index_management",
+    "deb": "opendistro-index-management/opendistro-index-management",
+    "rpm": "opendistro-index-management/opendistro-index-management",
+    "windows": "opendistro-index-management/opendistro_index_management",
+    "cutversion": "1.9.0.0",
+    "require_install": "true",
+    "category": "elasticsearch"
+  },
+  "knn": {
+    "git": "opendistro-for-elasticsearch/k-NN",
+    "zip": "opendistro-knn/opendistro-knn",
+    "deb": "opendistro-knn/opendistro-knn",
+    "rpm": "opendistro-knn/opendistro-knn",
+    "windows": "none",
+    "cutversion": "1.9.0.0",
+    "require_install": "true",
+    "category": "elasticsearch"
+  },
+  "knnlib": {
+    "git": "opendistro-for-elasticsearch/k-NN",
+    "zip": "opendistro-libs/opendistro-knnlib/opendistro-knnlib",
+    "deb": "opendistro-knnlib/opendistro-knnlib",
+    "rpm": "opendistro-knnlib/opendistro-knnlib",
+    "windows": "none",
+    "cutversion": "1.9.0.0",
+    "require_install": "false",
+    "category": "elasticsearch"
+  },
+  "anomaly-detection": {
+    "git": "opendistro-for-elasticsearch/anomaly-detection",
+    "zip": "opendistro-anomaly-detection/opendistro-anomaly-detection",
+    "deb": "opendistro-anomaly-detection/opendistro-anomaly-detection",
+    "rpm": "opendistro-anomaly-detection/opendistro-anomaly-detection",
+    "windows": "opendistro-anomaly-detection/opendistro-anomaly-detection",
+    "cutversion": "1.9.0.0",
+    "require_install": "true",
+    "category": "elasticsearch"
+  },
+  "sql-workbench": {
+    "git": "opendistro-for-elasticsearch/sql",
+    "zip": "opendistro-sql-workbench/opendistro-sql-workbench",
+    "deb": "none",
+    "rpm": "none",
+    "windows": "none",
+    "cutversion": "1.9.0.0",
+    "require_install": "true",
+    "category": "kibana"
+  },
+  "anomaly-detection-kibana": {
+    "git": "opendistro-for-elasticsearch/anomaly-detection-kibana-plugin",
+    "zip": "opendistro-anomaly-detection/opendistro-anomaly-detection-kibana",
+    "deb": "none",
+    "rpm": "none",
+    "windows": "none",
+    "cutversion": "1.9.0.0",
+    "require_install": "true",
+    "category": "kibana"
+  },
+  "security-kibana": {
+    "git": "opendistro-for-elasticsearch/security-kibana-plugin",
+    "zip": "opendistro-security/opendistro_security_kibana_plugin",
+    "deb": "none",
+    "rpm": "none",
+    "windows": "none",
+    "cutversion": "1.9.0.0",
+    "require_install": "true",
+    "category": "kibana"
+  },
+  "alerting-kibana": {
+    "git": "opendistro-for-elasticsearch/alerting-kibana-plugin",
+    "zip": "opendistro-alerting/opendistro-alerting",
+    "deb": "none",
+    "rpm": "none",
+    "windows": "none",
+    "cutversion": "1.9.0.0",
+    "require_install": "true",
+    "category": "kibana"
+  },
+  "index-management-kibana": {
+    "git": "opendistro-for-elasticsearch/index-management-kibana-plugin",
+    "zip": "opendistro-index-management/opendistro_index_management_kibana",
+    "deb": "none",
+    "rpm": "none",
+    "windows": "none",
+    "cutversion": "1.9.0.0",
+    "require_install": "true",
+    "category": "kibana"
+  },
+  "sql-cli": {
+    "git": "opendistro-for-elasticsearch/sql",
+    "zip": "opendistro-sql-cli/odfe-sql-cli",
+    "deb": "none",
+    "rpm": "none",
+    "windows": "none",
+    "cutversion": "1.9.0.0",
+    "require_install": "true",
+    "category": "client"
+  },
+  "sql-jdbc": {
+    "git": "opendistro-for-elasticsearch/sql",
+    "zip": "opendistro-sql-jdbc/opendistro-sql-jdbc",
+    "deb": "none",
+    "rpm": "none",
+    "windows": "none",
+    "cutversion": "1.9.0.0",
+    "require_install": "true",
+    "category": "client"
+  },
+  "sql-odbc-macos-64bit": {
+    "git": "opendistro-for-elasticsearch/sql",
+    "zip": "opendistro-sql-odbc/mac/Open Distro for Elasticsearch SQL ODBC Driver 64-bit",
+    "deb": "none",
+    "rpm": "none",
+    "windows": "none",
+    "cutversion": "1.9.0.0",
+    "require_install": "true",
+    "category": "client"
+  },
+  "sql-odbc-windows-64bit": {
+    "git": "opendistro-for-elasticsearch/sql",
+    "zip": "opendistro-sql-odbc/windows/Open Distro for Elasticsearch SQL ODBC Driver 64-bit",
+    "deb": "none",
+    "rpm": "none",
+    "windows": "none",
+    "cutversion": "1.9.0.0",
+    "require_install": "true",
+    "category": "client"
+  },
+  "sql-odbc-windows-32bit": {
+    "git": "opendistro-for-elasticsearch/sql",
+    "zip": "opendistro-sql-odbc/windows/Open Distro for Elasticsearch SQL ODBC Driver 32-bit",
+    "deb": "none",
+    "rpm": "none",
+    "windows": "none",
+    "cutversion": "1.9.0.0",
+    "require_install": "true",
+    "category": "client"
+  },
+  "perf-top": {
+    "git": "opendistro-for-elasticsearch/perftop",
+    "zip": "perf-top",
+    "deb": "none",
+    "rpm": "none",
+    "windows": "none",
+    "cutversion": "1.9.0.0",
+    "require_install": "true",
+    "category": "perf-top"
+  }
 }
+

--- a/bin/version-info
+++ b/bin/version-info
@@ -19,14 +19,16 @@
 # Maintainer:    ODFE Infra Team
 # Language:      Python
 #
-# About:         Print the ES/ODFE version for the current/previous branches
+# About:         Print the ES/ODFE/VersionCut related information and values
 #                as defined in the 'version.json' file
 #
 # Usage:         [python] ./version-info $VERSION_TYPE
-#                $VERSION_TYPE: --od | --od-prev | --es | --es-prev (required)
+#                $VERSION_TYPE (required): --od | --od-prev | --od-next
+#                                          --es | --es-prev | --es-next
+#                                          --is-cut
 #
 # Starting Date: 2019-05-15
-# Modified Date: 2020-07-30
+# Modified Date: 2020-08-24
 ###############################################################################################
 
 import sys
@@ -64,6 +66,10 @@ def get_od_version(user_param):
         else:
           return(get_hard_coded_version('odVersion', 'current'))
 
+def get_version_cut(user_param):
+    if user_param == '--is-cut':
+      return(get_hard_coded_version('versionCut', 'is_cut'))
+
 if __name__ == '__main__':
     # Provide a shell compatible interface, defaults to OD version
     if len(sys.argv) == 2 :
@@ -72,8 +78,16 @@ if __name__ == '__main__':
             print(get_es_version(arg_value))
         elif (arg_value == '--od') or (arg_value == '--od-prev') or (arg_value == '--od-next'):
             print(get_od_version(arg_value))
+        elif (arg_value == '--is-cut'):
+            print(get_version_cut(arg_value))
         else:
-            raise Exception('invalid argument, use --es OR --od OR --es-prev OR --od-prev OR --es-next OR --od-next')
+          raise Exception('invalid argument, use --es OR --od ',
+                          'OR --es-prev OR --od-prev ',
+                          'OR --es-next OR --od-next ',
+                          'OR --is-cut')
     else:
-      raise Exception('invalid argument, use --es OR --od OR --es-prev OR --od-prev OR --es-next OR --od-next')
+      raise Exception('invalid argument, use --es OR --od ',
+                      'OR --es-prev OR --od-prev ',
+                      'OR --es-next OR --od-next ',
+                      'OR --is-cut')
 

--- a/bin/version.json
+++ b/bin/version.json
@@ -8,5 +8,8 @@
     "previous": "1.9.0",
     "current": "1.10.0",
     "next": "1.10.1"
+  },
+  "versionCut": {
+    "is_cut": "false"
   }
 }

--- a/download_kibana_plugins.sh
+++ b/download_kibana_plugins.sh
@@ -5,23 +5,38 @@
 #set -e
 REPO_ROOT=`git rev-parse --show-toplevel`
 ROOT=`dirname $(realpath $0)`; echo $ROOT; cd $ROOT
-ES_VERSION=`$REPO_ROOT/bin/version-info --es`; echo $ES_VERSION
-OD_VERSION=`$REPO_ROOT/bin/version-info --od`; echo $OD_VERSION
+ES_VERSION=`$REPO_ROOT/bin/version-info --es`; echo ES_VERSION: $ES_VERSION
+OD_VERSION=`$REPO_ROOT/bin/version-info --od`; echo OD_VERSION: $OD_VERSION
+IS_CUT=`$REPO_ROOT/bin/version-info --is-cut`; echo IS_CUT: $IS_CUT
 S3_BUCKET="artifacts.opendistroforelasticsearch.amazon.com"
 PLUGIN_DIR="docker/build/kibana/plugins"
+plugin_version=$OD_VERSION
 
 # Please DO NOT change the orders, they have dependencies
-PLUGINS=`$REPO_ROOT/bin/plugins-info kibana`
+PLUGINS=`$REPO_ROOT/bin/plugins-info kibana zip --require-install-true`
+PLUGINS_ARRAY=( $PLUGINS )
+CUT_VERSIONS=`$REPO_ROOT/bin/plugins-info kibana cutversion --require-install-true`
+CUT_VERSIONS_ARRAY=( $CUT_VERSIONS )
 
 cd $ROOT/kibana
 mkdir $PLUGIN_DIR
 
-for plugin_path in $PLUGINS
+for index in ${!PLUGINS_ARRAY[@]}
 do
-  plugin_latest=`aws s3api list-objects --bucket $S3_BUCKET --prefix "downloads/kibana-plugins/${plugin_path}-${OD_VERSION}" --query 'Contents[].[Key]' --output text | sort | tail -n 1`
-  echo "downloading $plugin_latest"
-  (echo $plugin_latest | grep -qhi 'None') || (echo `echo $plugin_latest | awk -F '/' '{print $NF}'` >> $PLUGIN_DIR/plugins_kibana.list)
-  aws s3 cp "s3://${S3_BUCKET}/${plugin_latest}" "${PLUGIN_DIR}" --quiet; echo $?
+  if [ "$IS_CUT" = "true" ]
+  then
+    plugin_version=${CUT_VERSIONS_ARRAY[$index]}
+  fi
+
+  plugin_path=${PLUGINS_ARRAY[$index]}
+  plugin_latest=`aws s3api list-objects --bucket $S3_BUCKET --prefix "downloads/kibana-plugins/${plugin_path}-${plugin_version}" --query 'Contents[].[Key]' --output text | sort | tail -n 1`
+
+  if [ "$plugin_path" != "none" ]
+  then
+    echo "downloading $plugin_latest"
+    (echo $plugin_latest | grep -qhi 'None') || (echo `echo $plugin_latest | awk -F '/' '{print $NF}'` >> $PLUGIN_DIR/plugins_kibana.list)
+    aws s3 cp "s3://${S3_BUCKET}/${plugin_latest}" "${PLUGIN_DIR}" --quiet; echo $?
+  fi
 done
 
 ls -ltr $PLUGIN_DIR

--- a/download_plugins.sh
+++ b/download_plugins.sh
@@ -5,24 +5,38 @@
 #set -e
 REPO_ROOT=`git rev-parse --show-toplevel`
 ROOT=`dirname $(realpath $0)`; echo $ROOT; cd $ROOT
-ES_VERSION=`$REPO_ROOT/bin/version-info --es`; echo $ES_VERSION
-OD_VERSION=`$REPO_ROOT/bin/version-info --od`; echo $OD_VERSION
+ES_VERSION=`$REPO_ROOT/bin/version-info --es`; echo ES_VERSION: $ES_VERSION
+OD_VERSION=`$REPO_ROOT/bin/version-info --od`; echo OD_VERSION: $OD_VERSION
+IS_CUT=`$REPO_ROOT/bin/version-info --is-cut`; echo IS_CUT: $IS_CUT
 S3_BUCKET="artifacts.opendistroforelasticsearch.amazon.com"
 PLUGIN_DIR="docker/build/elasticsearch/plugins"
+plugin_version=$OD_VERSION
 
 # Please DO NOT change the orders, they have dependencies
-PLUGINS=`$REPO_ROOT/bin/plugins-info zip`
-echo PLUGINS $PLUGINS
+PLUGINS=`$REPO_ROOT/bin/plugins-info elasticsearch zip --require-install-true`
+PLUGINS_ARRAY=( $PLUGINS )
+CUT_VERSIONS=`$REPO_ROOT/bin/plugins-info elasticsearch cutversion --require-install-true`
+CUT_VERSIONS_ARRAY=( $CUT_VERSIONS )
 
 cd $ROOT/elasticsearch
 mkdir $PLUGIN_DIR
 
-for plugin_path in $PLUGINS
+for index in ${!PLUGINS_ARRAY[@]}
 do
-  plugin_latest=`aws s3api list-objects --bucket $S3_BUCKET --prefix "downloads/elasticsearch-plugins/${plugin_path}-${OD_VERSION}" --query 'Contents[].[Key]' --output text | sort | tail -n 1`
-  echo "downloading $plugin_latest"
-  (echo $plugin_latest | grep -qhi 'None') || (echo `echo $plugin_latest | awk -F '/' '{print $NF}'` >> $PLUGIN_DIR/plugins.list)
-  aws s3 cp "s3://${S3_BUCKET}/${plugin_latest}" "${PLUGIN_DIR}" --quiet; echo $?
+  if [ "$IS_CUT" = "true" ]
+  then
+    plugin_version=${CUT_VERSIONS_ARRAY[$index]}
+  fi
+
+  plugin_path=${PLUGINS_ARRAY[$index]}
+  plugin_latest=`aws s3api list-objects --bucket $S3_BUCKET --prefix "downloads/elasticsearch-plugins/${plugin_path}-${plugin_version}" --query 'Contents[].[Key]' --output text | sort | tail -n 1`
+
+  if [ "$plugin_path" != "none" ]
+  then
+    echo "downloading $plugin_latest"
+    (echo $plugin_latest | grep -qhi 'None') || (echo `echo $plugin_latest | awk -F '/' '{print $NF}'` >> $PLUGIN_DIR/plugins.list)
+    aws s3 cp "s3://${S3_BUCKET}/${plugin_latest}" "${PLUGIN_DIR}" --quiet; echo $?
+  fi
 done
 
 ls -ltr $PLUGIN_DIR

--- a/elasticsearch/linux_distributions/build.gradle
+++ b/elasticsearch/linux_distributions/build.gradle
@@ -57,7 +57,7 @@ ext {
     new ByteArrayOutputStream().withStream { os3 ->
       def result3 = exec {
         executable = '../../bin/plugins-info'
-        args = ['rpm']
+        args = ['elasticsearch', 'rpm', '--require-install-true']
         standardOutput = os3
       }
       ext.plugin_names = os3.toString()
@@ -66,7 +66,7 @@ ext {
     new ByteArrayOutputStream().withStream { os4 ->
       def result4 = exec {
         executable = '../../bin/plugins-info'
-        args = ['rpm', '--git']
+        args = ['elasticsearch', 'git', '--require-install-true']
         standardOutput = os4
       }
       ext.plugin_git = os4.toString().replaceAll("\n", ",")
@@ -74,29 +74,49 @@ ext {
 
     new ByteArrayOutputStream().withStream { os5 ->
       def result5 = exec {
-        executable = '../../.github/scripts/plugin_tag.sh'
-        args = [ext.plugin_git, opendistroVersion]
+        executable = '../../bin/version-info'
+        args = ['--is-cut']
         standardOutput = os5
       }
-      ext.plugin_versions = os5.toString().replaceAll("v", "")
+      ext.is_cut = os5.toString().trim()
+    }
+    println("is_cut: " + ext.is_cut)
+
+   if (ext.is_cut.equals("true")) {
+      new ByteArrayOutputStream().withStream { os6 ->
+        def result6 = exec {
+          executable = '../../bin/plugins-info'
+          args = ['elasticsearch', 'cutversion', '--require-install-true']
+          standardOutput = os6
+        }
+        ext.plugin_versions = os6.toString()
+        println("Version is cut")
+      }
+    }
+    else {
+      new ByteArrayOutputStream().withStream { os7 ->
+        def result7 = exec {
+          executable = '../../.github/scripts/plugin_tag.sh'
+          args = [ext.plugin_git, opendistroVersion]
+          standardOutput = os7
+        }
+        ext.plugin_versions = os7.toString().replaceAll("v", "")
+        println("Version not cut")
+      }
     }
 
-    new ByteArrayOutputStream().withStream { os6 ->
-      def result6 = exec {
+    new ByteArrayOutputStream().withStream { os8 ->
+      def result8 = exec {
         executable = '../../bin/version-info'
         args = ['--od-next']
-        standardOutput = os6
+        standardOutput = os8
       }
-      ext.plugin_versions_next = os6.toString().trim() + ".0"
+      ext.plugin_versions_next = os8.toString().trim() + ".0"
     }
 
     pname_arr = ext.plugin_names.split("\n").toList()
     pver_arr = ext.plugin_versions.split("\n").toList()
     pver_next = ext.plugin_versions_next
-
-    // these are not direct dependencies to ODFE ES
-    // plugin owners handle these in their own build scripts
-    indirect_deps = ['opendistro-knnlib']
 
 }
 group 'com.amazon.opendistroforelasticsearch'
@@ -113,17 +133,16 @@ ospackage {
     // setup package requirements
     requires('elasticsearch-oss', elasticsearchVersion, EQUAL)
 
-    for (int i = 0; i < pname_arr.size; i++){
-      String pluginName = pname_arr[i].substring(pname_arr[i].lastIndexOf("/") + 1)
+    for (int i = 0; i < pname_arr.size; i++) {
+      String pluginName = pname_arr[i].substring(pname_arr[i].lastIndexOf("/") + 1).trim()
       String pluginVersion = pver_arr[i].trim()
       String pluginVersionNext = pver_next.trim()
 
-      for (int j = 0; j < indirect_deps.size; j++)
-        if (!pluginName.contains(indirect_deps[j])){
-          println(pluginName + ": >= " + pluginVersion + " | < " + pluginVersionNext)
-          requires(pluginName, pluginVersion, GREATER | EQUAL)
-          requires(pluginName, pluginVersionNext, LESS)
-        }
+      if (!pluginName.contains("none")) {
+        println(pluginName + ": >= " + pluginVersion + " | < " + pluginVersionNext)
+        requires(pluginName, pluginVersion, GREATER | EQUAL)
+        requires(pluginName, pluginVersionNext, LESS)
+      }
     } 
 
     packager = 'Amazon'

--- a/elasticsearch/windows/opendistro-windows-build.sh
+++ b/elasticsearch/windows/opendistro-windows-build.sh
@@ -3,18 +3,22 @@ set -e
 
 REPO_ROOT=`git rev-parse --show-toplevel`
 ROOT=`dirname $(realpath $0)`; echo $ROOT; cd $ROOT
-ES_VERSION=`$REPO_ROOT/bin/version-info --es`; echo $ES_VERSION
-OD_VERSION=`$REPO_ROOT/bin/version-info --od`; echo $OD_VERSION
+ES_VERSION=`$REPO_ROOT/bin/version-info --es`; echo ES_VERSION: $ES_VERSION
+OD_VERSION=`$REPO_ROOT/bin/version-info --od`; echo OD_VERSION: $OD_VERSION
+IS_CUT=`$REPO_ROOT/bin/version-info --is-cut`; echo IS_CUT: $IS_CUT
 S3_BUCKET="artifacts.opendistroforelasticsearch.amazon.com"
 ARTIFACTS_URL="https://d3g5vo6xdbdb9a.cloudfront.net"
 PACKAGE_NAME="opendistroforelasticsearch"
 TARGET_DIR="$ROOT/target"
+plugin_version=$OD_VERSION
 
 # Please DO NOT change the orders, they have dependencies
-PLUGINS=`$REPO_ROOT/bin/plugins-info windows`
+PLUGINS=`$REPO_ROOT/bin/plugins-info elasticsearch windows --require-install-true`
+PLUGINS_ARRAY=( $PLUGINS )
+CUT_VERSIONS=`$REPO_ROOT/bin/plugins-info elasticsearch cutversion --require-install-true`
+CUT_VERSIONS_ARRAY=( $CUT_VERSIONS )
 
 basedir="${ROOT}/elasticsearch-${ES_VERSION}/plugins"
-#PLUGINS_CHECKS=`$REPO_ROOT/bin/plugins-info zip | awk -F '/' '{print $2}' | sed "s@^@$basedir\/@g"`
 
 mkdir -p $TARGET_DIR
 mkdir -p $PACKAGE_NAME-$OD_VERSION
@@ -27,11 +31,21 @@ unzip -q elasticsearch-oss-$ES_VERSION-windows-x86_64.zip
 rm -rf elasticsearch-oss-$ES_VERSION-windows-x86_64.zip
 
 # Install plugins
-for plugin_path in $PLUGINS
+for index in ${!PLUGINS_ARRAY[@]}
 do
-  plugin_latest=`aws s3api list-objects --bucket $S3_BUCKET --prefix "downloads/elasticsearch-plugins/${plugin_path}-${OD_VERSION}" --query 'Contents[].[Key]' --output text | sort | tail -n 1`
-  echo "installing $plugin_latest"
-  $ROOT/elasticsearch-$ES_VERSION/bin/elasticsearch-plugin install --batch "${ARTIFACTS_URL}/${plugin_latest}"; \
+  if [ "$IS_CUT" = "true" ]
+  then
+    plugin_version=${CUT_VERSIONS_ARRAY[$index]}
+  fi
+
+  plugin_path=${PLUGINS_ARRAY[$index]}
+  plugin_latest=`aws s3api list-objects --bucket $S3_BUCKET --prefix "downloads/elasticsearch-plugins/${plugin_path}-${plugin_version}" --query 'Contents[].[Key]' --output text | sort | tail -n 1`
+
+  if [ "$plugin_path" != "none" ]
+  then
+    echo "installing $plugin_latest"
+    $ROOT/elasticsearch-$ES_VERSION/bin/elasticsearch-plugin install --batch "${ARTIFACTS_URL}/${plugin_latest}"; \
+  fi
 done
 
 # List Plugins
@@ -56,6 +70,7 @@ echo $?
 # Build the exe
 install4j8.0.4/bin/install4jc -d $TARGET_DIR -D sourcedir=./$PACKAGE_NAME-$OD_VERSION,version=$OD_VERSION --license="L-M8-AMAZON_DEVELOPMENT_CENTER_INDIA_PVT_LTD#50047687020001-3rhvir3mkx479#484b6" ./ODFE.install4j
 
+# List installed plugins
 ls -ltr $TARGET_DIR
 
 # Upload top S3

--- a/kibana/linux_distributions/opendistro-kibana-build.sh
+++ b/kibana/linux_distributions/opendistro-kibana-build.sh
@@ -28,19 +28,23 @@ set -e
 # Initialize directories
 REPO_ROOT=`git rev-parse --show-toplevel`
 ROOT=`dirname $(realpath $0)`; echo $ROOT; cd $ROOT
-ES_VERSION=`$REPO_ROOT/bin/version-info --es`; echo $ES_VERSION
-OD_VERSION=`$REPO_ROOT/bin/version-info --od`; echo $OD_VERSION
+ES_VERSION=`$REPO_ROOT/bin/version-info --es`; echo ES_VERSION: $ES_VERSION
+OD_VERSION=`$REPO_ROOT/bin/version-info --od`; echo OD_VERSION: $OD_VERSION
+IS_CUT=`$REPO_ROOT/bin/version-info --is-cut`; echo IS_CUT: $IS_CUT
 PACKAGE_TYPE=$1
 S3_BUCKET="artifacts.opendistroforelasticsearch.amazon.com"
 ARTIFACTS_URL="https://d3g5vo6xdbdb9a.cloudfront.net"
 PACKAGE_NAME="opendistroforelasticsearch-kibana"
 TARGET_DIR="$ROOT/target"
+plugin_version=$OD_VERSION
 
 # Please DO NOT change the orders, they have dependencies
-PLUGINS=`$REPO_ROOT/bin/plugins-info kibana`
+PLUGINS=`$REPO_ROOT/bin/plugins-info kibana zip --require-install-true`
+PLUGINS_ARRAY=($PLUGINS )
+CUT_VERSIONS=`$REPO_ROOT/bin/plugins-info kibana cutversion --require-install-true`
+CUT_VERSIONS_ARRAY=( $CUT_VERSIONS )
 
 basedir="${ROOT}/${PACKAGE_NAME}/plugins"
-PLUGINS_CHECKS=`$REPO_ROOT/bin/plugins-info kibana | awk -F '/' '{print $2}' | sed "s@^@$basedir\/@g"`
 
 echo $ROOT
 
@@ -65,11 +69,20 @@ curl -Ls "https://artifacts.elastic.co/downloads/kibana/kibana-oss-$ES_VERSION-l
 
 # Install required plugins
 echo "installing open distro plugins"
-for plugin_path in $PLUGINS
+for index in ${!PLUGINS_ARRAY[@]}
 do
-  plugin_latest=`aws s3api list-objects --bucket $S3_BUCKET --prefix "downloads/kibana-plugins/${plugin_path}-${OD_VERSION}" --query 'Contents[].[Key]' --output text | sort | tail -n 1`
-  echo "installing $plugin_latest"
-  $PACKAGE_NAME/bin/kibana-plugin --allow-root install "${ARTIFACTS_URL}/${plugin_latest}"
+  if [ "$IS_CUT" = "true" ]
+  then
+    plugin_version=${CUT_VERSIONS_ARRAY[$index]}
+  fi
+  plugin_path=${PLUGINS_ARRAY[$index]}
+  plugin_latest=`aws s3api list-objects --bucket $S3_BUCKET --prefix "downloads/kibana-plugins/${plugin_path}-${plugin_version}" --query 'Contents[].[Key]' --output text | sort | tail -n 1`
+
+  if [ "$plugin_path" != "none" ]
+  then
+    echo "installing $plugin_latest"
+    $PACKAGE_NAME/bin/kibana-plugin --allow-root install "${ARTIFACTS_URL}/${plugin_latest}"
+  fi
 done
 
 # List Plugins


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/opendistro-infra/issues/264

------

*Description of changes:*
This PR is to cut the versions of the plugins after a final distro builds so we can lock them up for rebuilds later.
In bin/version.json:
* if is_cut is false, plugin downloads/installation will take the latest version from S3 bucket
* if is_cut is true, plugin downloads/installation will take the hard-coded version in bin/plugins.json

* plugins-info and plugins.json affect these scripts:
   ```
   download_kibana_plugins.sh
   download_plugins.sh
   elasticsearch/linux_distributions/opendistro-tar-build.sh
   elasticsearch/linux_distributions/build.gradle
   elasticsearch/windows/opendistro-windows-build.sh
   kibana/linux_distributions/opendistro-kibana-build.sh
   ```
  
------

*Test Results:*
* I am using 1.9.0 related versions in the tests. If is_cut true, security plugin uses 1.9.0.0; if is_cut false, security plugin uses 1.9.0.1, this is an indication whether my change works in using hard-coded version cuts in plugins.json or not.

* TAR:
  * IS_CUT: false
  https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/227879856
  * IS_CUT: true
  https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/227860325
  
* WINDOWS:
  * IS_CUT: false
  https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/227887800
  * IS_CUT: true
  https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/227891053

* DEB/RPM (error expected, since I am just dpkg -i to make sure that the version dependencies works)
   DEB and RPM use the same build.gradle so test DEB also test RPM buildings
  * IS_CUT: false
  https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/227919651
  * IS_CUT: true
  https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/227913274

* DOCKER:
  * IS_CUT: false
  https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/229263953
  * IS_CUT: true
  https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/229291562

* AMI is based on RPM so no need to test individually

------

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
