### PR TITLE
Enable docker ci builds to run per schedule

### DIFF
--- a/.github/workflows/staging-build-docker-ci.yml
+++ b/.github/workflows/staging-build-docker-ci.yml
@@ -1,8 +1,8 @@
 name: Webhook Build ES Docker CI on Dispatch
 
 on: 
-  #schedule:
-  #  - cron: '0 0,15 * * *'
+  schedule:
+    - cron: '0 0,15 * * *'
   repository_dispatch:
     types: [staging-build-docker-ci]
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/opendistro-infra/issues/251

*Description of changes:*
This PR is to enable daily docker ci builds by using the github workflow crontab schedules

*Test Results:*
No need as it is just enabling a schedule

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
