### PR TITLE
Fix Kibana SSL on example docker-compose.yml

### DIFF
--- a/kibana/docker/docker-compose.yml
+++ b/kibana/docker/docker-compose.yml
@@ -31,7 +31,8 @@ services:
     # only be used for experimentation, never in production.
     #
     # environment:
-    #   - SERVER_SSL_CERT=/usr/share/kibana/config/opendistroforelasticsearch.example.org.crt
+    #   - SERVER_SSL_ENABLED=true
+    #   - SERVER_SSL_CERTIFICATE=/usr/share/kibana/config/opendistroforelasticsearch.example.org.cert
     #   - SERVER_SSL_KEY=/usr/share/kibana/config/opendistroforelasticsearch.example.org.key
 
   elasticsearch:


### PR DESCRIPTION
*Description of changes:*

In order to enable SSL for the Kibana container these are the correct env vars to pass on the docker-compose.yml.

```
- SERVER_SSL_ENABLED=true
- SERVER_SSL_CERTIFICATE=/usr/share/kibana/config/opendistroforelasticsearch.example.org.cert
- SERVER_SSL_KEY=/usr/share/kibana/config/opendistroforelasticsearch.example.org.key
```


Also fixed the cert path extension, from `crt` to `cert`.

*Test Results:*

Now Kibana container has SSL enabled when used with these env variables.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
