### PR TITLE
Resolve check_plugins.sh issues as we update plugins.json in #357

### DIFF
--- a/.github/scripts/check_plugin.sh
+++ b/.github/scripts/check_plugin.sh
@@ -14,7 +14,10 @@
 #                GREEN:  plugin artifact is in S3
 #
 # Usage:         ./check_plugin.sh $PLUGIN_TYPES [$ODFE_VERSION]
-#                $PLUGIN_TYPES: zip,deb,rpm,kibana,clidvr,perftop (optional)
+#                $PLUGIN_TYPES: elasticsearch_zip | elasticsearch_rpm | elasticsearch_deb
+#                               kibana_zip
+#                               client_zip | perftop_zip
+#                               (optional, use "," to separate multiple entries in one run)
 #                $ODFE_VERSION: x.y.z (optional)
 #
 # Starting Date: 2020-05-29
@@ -28,12 +31,12 @@
 REPO_ROOT=`git rev-parse --show-toplevel`
 ROOT=`dirname $(realpath $0)`; echo $ROOT; cd $ROOT
 S3_BUCKET="artifacts.opendistroforelasticsearch.amazon.com"
-S3_DIR_zip="downloads/elasticsearch-plugins"
-S3_DIR_rpm="downloads/rpms"
-S3_DIR_deb="downloads/debs"
-S3_DIR_kibana="downloads/kibana-plugins"
-S3_DIR_clidvr="downloads/elasticsearch-clients"
-S3_DIR_perftop="downloads/perftop"
+S3_DIR_elasticsearch_zip="downloads/elasticsearch-plugins"
+S3_DIR_elasticsearch_rpm="downloads/rpms"
+S3_DIR_elasticsearch_deb="downloads/debs"
+S3_DIR_kibana_zip="downloads/kibana-plugins"
+S3_DIR_client_zip="downloads/elasticsearch-clients"
+S3_DIR_perftop_zip="downloads/perftop"
 TSCRIPT_NEWLINE="%0D%0A"
 RUN_STATUS=0 # 0 is success, 1 is failure
 PLUGIN_TYPES=$1
@@ -45,8 +48,8 @@ if [ "$#" -gt 2 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]
 then
   echo "Please assign at most 2 parameters when running this script"
   echo "Example: $0 \$PLUGIN_TYPES [\$ODFE_VERSION]"
-  echo "Example: $0 \"tar\""
-  echo "Example: $0 \"rpm,kibana\" \"1.7.0\""
+  echo "Example: $0 \"elasticsearch_zip\""
+  echo "Example: $0 \"elasticsearch_zip,kibana_zip\" \"1.7.0\""
   exit 1
 fi
 
@@ -56,7 +59,7 @@ echo "PLUGIN_TYPES is: $PLUGIN_TYPES"
 if [ -z "$PLUGIN_TYPES" ]
 then
   # Kibana currently have the same plugins for all distros
-  PLUGIN_TYPES="zip,deb,rpm,kibana,clidvr,perftop" # separate the types by comma here
+  PLUGIN_TYPES="elasticsearch_zip,elasticsearch_deb,elasticsearch_rpm,kibana_zip,client_zip,perftop_zip" # separate the types by comma here
   echo "Use default PLUGIN_TYPES: $PLUGIN_TYPES"
 fi
 PLUGIN_TYPES=`echo $PLUGIN_TYPES | tr '[:upper:]' '[:lower:]'`
@@ -76,8 +79,9 @@ IFS=,
 for plugin_type in $PLUGIN_TYPES
 do
   # Try to dynamically assign the variables based on PLUGIN_TYPES
-  PLUGINS=`$REPO_ROOT/bin/plugins-info $plugin_type`
-  PLUGINS_GIT=`$REPO_ROOT/bin/plugins-info $plugin_type --git | tr '\n' ' '`
+  IFS='_' read -r -a plugin_type_array <<< $plugin_type
+  PLUGINS=`$REPO_ROOT/bin/plugins-info ${plugin_type_array[0]} ${plugin_type_array[1]} --require-install-true`
+  PLUGINS_GIT=`$REPO_ROOT/bin/plugins-info ${plugin_type_array[0]} git --require-install-true | tr '\n' ' '`
   eval S3_DIR='$'S3_DIR_${plugin_type}
   plugin_arr=()
   unavailable_plugin=()
@@ -168,14 +172,8 @@ do
   #cd /home/runner/work/opendistro-build/opendistro-build/
   cd $ROOT
 
-  if [ "$plugin_type" = "kibana" ]
-  then
-    echo "<h1><u>[KIBANA] Plugins ($ODFE_VERSION) Availability Checks for ( $plugin_type $tot_plugins/${#plugin_arr[*]} )</u></h1>" >> message.md
-    echo ":bar_chart: [KIBANA] Plugins ($ODFE_VERSION) for ( $plugin_type $tot_plugins/${#plugin_arr[*]} ): $TSCRIPT_NEWLINE" >> chime_message.md
-  else
-    echo "<h1><u>[ES] Plugins ($ODFE_VERSION) Availability Checks for ( $plugin_type $tot_plugins/${#plugin_arr[*]} )</u></h1>" >> message.md
-    echo ":mag_right: [ES] Plugins ($ODFE_VERSION) for ( $plugin_type $tot_plugins/${#plugin_arr[*]} ): $TSCRIPT_NEWLINE" >> chime_message.md
-  fi
+  echo "<h1><u>[$plugin_type] Plugins ($ODFE_VERSION) Availability Checks for ( $plugin_type $tot_plugins/${#plugin_arr[*]} )</u></h1>" >> message.md
+  echo "[$plugin_type] Plugins ($ODFE_VERSION) for ( $plugin_type $tot_plugins/${#plugin_arr[*]} ): $TSCRIPT_NEWLINE" >> chime_message.md
   
   echo "<h2><p style='color:red;'><b>NOT AVAILABLE</b></p></h2>" >> message.md
   if [ "${#unavailable_plugin[*]}" -gt 0 ]

--- a/.github/scripts/check_plugin.sh
+++ b/.github/scripts/check_plugin.sh
@@ -21,7 +21,7 @@
 #                $ODFE_VERSION: x.y.z (optional)
 #
 # Starting Date: 2020-05-29
-# Modified Date: 2020-08-19
+# Modified Date: 2020-08-31
 ###############################################################################################
 
 # Please leave it commented as aws s3 will fail if no plugin presents

--- a/.github/scripts/check_plugin.sh
+++ b/.github/scripts/check_plugin.sh
@@ -172,8 +172,8 @@ do
   #cd /home/runner/work/opendistro-build/opendistro-build/
   cd $ROOT
 
-  echo "<h1><u>[$plugin_type] Plugins ($ODFE_VERSION) Availability Checks for ( $plugin_type $tot_plugins/${#plugin_arr[*]} )</u></h1>" >> message.md
-  echo "[$plugin_type] Plugins ($ODFE_VERSION) for ( $plugin_type $tot_plugins/${#plugin_arr[*]} ): $TSCRIPT_NEWLINE" >> chime_message.md
+  echo "<h1><u>[$plugin_type] Plugins ($ODFE_VERSION) Availability Checks for ( $tot_plugins/${#plugin_arr[*]} )</u></h1>" >> message.md
+  echo "[$plugin_type] Plugins ($ODFE_VERSION) for ( $tot_plugins/${#plugin_arr[*]} ): $TSCRIPT_NEWLINE" >> chime_message.md
   
   echo "<h2><p style='color:red;'><b>NOT AVAILABLE</b></p></h2>" >> message.md
   if [ "${#unavailable_plugin[*]}" -gt 0 ]

--- a/.github/workflows/staging-build-deb.yml
+++ b/.github/workflows/staging-build-deb.yml
@@ -20,7 +20,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Run check_plugin scripts
-        run: .github/scripts/check_plugin.sh "deb,kibana"; exit `cat /tmp/plugin_status.check`
+        run: .github/scripts/check_plugin.sh "elasticsearch_deb,kibana_zip"; exit `cat /tmp/plugin_status.check`
 
   build-es-artifacts:
     needs: [plugin-availability]

--- a/.github/workflows/staging-build-rpm.yml
+++ b/.github/workflows/staging-build-rpm.yml
@@ -20,7 +20,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Run check_plugin scripts
-        run: .github/scripts/check_plugin.sh "rpm,kibana"; exit `cat /tmp/plugin_status.check`
+        run: .github/scripts/check_plugin.sh "elasticsearch_rpm,kibana_zip"; exit `cat /tmp/plugin_status.check`
 
   build-es-artifacts:
     needs: [plugin-availability]

--- a/.github/workflows/staging-build-tar.yml
+++ b/.github/workflows/staging-build-tar.yml
@@ -20,7 +20,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Run check_plugin scripts
-        run: .github/scripts/check_plugin.sh "zip,kibana"; exit `cat /tmp/plugin_status.check`
+        run: .github/scripts/check_plugin.sh "elasticsearch_zip,kibana_zip"; exit `cat /tmp/plugin_status.check`
 
   build-es-artifacts:
     needs: [plugin-availability]

--- a/bin/plugins-info
+++ b/bin/plugins-info
@@ -9,7 +9,7 @@
 #                as defined in the 'plugins.json' file
 #
 # Usage:         ./plugins-info $PLUGINS_TYPE $RETURN_TYPE [$REQUIRE_INSTALL]
-#                $PLUGINS_TYPE: elasticsearch | kibana | client | perf-top  (required)
+#                $PLUGINS_TYPE: elasticsearch | kibana | client | perftop  (required)
 #                $RETURN_TYPE: zip | deb | rpm | windows | git | cutversion (required)
 #                $REQUIRE_INSTALL: <default to both> (optional)
 #                                  --require-install-true

--- a/bin/plugins.json
+++ b/bin/plugins.json
@@ -189,7 +189,7 @@
     "require_install": "true",
     "category": "client"
   },
-  "perf-top": {
+  "perftop": {
     "git": "opendistro-for-elasticsearch/perftop",
     "zip": "perf-top",
     "deb": "none",
@@ -197,7 +197,7 @@
     "windows": "none",
     "cutversion": "1.9.0.0",
     "require_install": "true",
-    "category": "perf-top"
+    "category": "perftop"
   }
 }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/opendistro-infra/issues/251

*Description of changes:*
This PR is to resolve check_plugins.sh issues as we update plugins.json in #357. 
The check_plugin.sh relies on plugins-info and plugins.json to provide plugin lists.
Due to the changes in #357 the usage and formats of the plugins-info & plugins.json is changed now.
However, check_plugin.sh did not make corresponding changes, thus fail the check due to not able to obtain the plugin list.
This PR fixed the issue by correctly calling plugins-info in check_plugin.sh, and the related workflows.

*Test Results:*
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/233601325
The failure is only for email not for plugin checks, will fix email in a later PR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
