### PR TITLE
Disable CI Docker Daily Builds for ODFE 1.10.0

### DIFF
--- a/.github/workflows/staging-build-docker-ci.yml
+++ b/.github/workflows/staging-build-docker-ci.yml
@@ -1,8 +1,8 @@
 name: Webhook Build ES Docker CI on Dispatch
 
 on: 
-  schedule:
-    - cron: '0 0,15 * * *'
+  #schedule:
+  #  - cron: '0 0,15 * * *'
   repository_dispatch:
     types: [staging-build-docker-ci]
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/opendistro-infra/issues/251

*Description of changes:*
This PR is to disable CI docker daily builds as we have completed ODFE 1.10.0 Step 1&2 and does not need this CI docker image anymore

*Test Results:*
No need as we are just disabling the schedules in the workflows

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
