### PR TITLE
Disable check_plugin workflow daily checks for ODFE 1.10.0

### DIFF
--- a/.github/workflows/check-plugin.yml
+++ b/.github/workflows/check-plugin.yml
@@ -1,8 +1,8 @@
 name: Check Plugin Availability Main
 
 on:
-  schedule:
-    - cron: '0 0,15 * * *'
+  #schedule:
+  #  - cron: '0 0,15 * * *'
   repository_dispatch:
     types: [check-plugin]
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/opendistro-infra/issues/251

*Description of changes:*
This PR is to disable the check_plugin workflow daily checks as Step 1&2 of ODFE 1.10.0 are completed.

*Test Results:*
No need to as we are just disable the scheduling

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
