### PR TITLE
Helm master nodes allows extraVolumeMounts when securityconfig disabled 

### DIFF
--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -232,10 +232,10 @@ spec:
         - mountPath: {{ .Values.elasticsearch.securityConfig.path }}
           name: security-config
         {{- end }}
+        {{- end }}
 {{- if .Values.elasticsearch.extraVolumeMounts }}
 {{ toYaml .Values.elasticsearch.extraVolumeMounts | indent 8 }}
 {{- end }}
-      {{- end }}
       volumes:
       - name: config
         secret:


### PR DESCRIPTION
*Issue #, if available:*
N/A

Current behavior:
When the `securityconfig` is disabled, `extraVolumeMounts` of master nodes will also be disabled.

Expected behavior:
When the `securityconfig` is disabled, `extraVolumeMounts` of master nodes will remains.

*Description of changes:*

This PR allows master nodes to have extra volume mounts when `securityconfig` is disabled.

*Test Results:*

I am not sure how to test Helm charts properly, but I have tested it in my local environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
