### PR TITLE
Increase the maximum script compilation rate in setup_runners_service.sh

### DIFF
--- a/.github/scripts/setup_runners_service.sh
+++ b/.github/scripts/setup_runners_service.sh
@@ -107,11 +107,15 @@ if [ "$SETUP_DISTRO" = "zip" ]
 then
   mkdir -p snapshots
   echo "path.repo: [\"$PWD/snapshots\"]" >> $ES_ROOT/config/elasticsearch.yml
+  # Increase the number of allowed script compilations. The SQL integ tests use a lot of scripts.
+  echo "script.context.field.max_compilations_rate: 1000/1m" >> $ES_ROOT/config/elasticsearch.yml
 elif [ "$SETUP_DISTRO" = "docker" ]
 then
   echo "FROM opendistroforelasticsearch/opendistroforelasticsearch:$OD_VERSION" >> Dockerfile
   echo "RUN echo ''  >> /usr/share/elasticsearch/config/elasticsearch.yml" >> Dockerfile
   echo "RUN echo \"path.repo: [\\\"/usr/share/elasticsearch\\\"]\" >> /usr/share/elasticsearch/config/elasticsearch.yml" >> Dockerfile
+  # Increase the number of allowed script compilations. The SQL integ tests use a lot of scripts.
+  echo "RUN echo \"script.context.field.max_compilations_rate: 1000/1m\" >> /usr/share/elasticsearch/config/elasticsearch.yml" >> Dockerfile
   docker build -t odfe-http:security -f Dockerfile .
   sleep 5
   docker run -d -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" --name $DOCKER_NAME odfe-http:security
@@ -125,6 +129,8 @@ else
   sudo chmod 777 /etc/elasticsearch/elasticsearch.yml
   sudo sed -i '/path.logs/a path.repo: ["/home/repo"]' /etc/elasticsearch/elasticsearch.yml
   sudo sed -i /^node.max_local_storage_nodes/d /etc/elasticsearch/elasticsearch.yml
+  # Increase the number of allowed script compilations. The SQL integ tests use a lot of scripts.
+  sudo echo "script.context.field.max_compilations_rate: 1000/1m" >> /etc/elasticsearch/elasticsearch.yml
 fi
 
 if [ "$SETUP_ACTION" = "--es" ]


### PR DESCRIPTION
### Issue
https://github.com/opendistro-for-elasticsearch/opendistro-infra/issues/251

The SQL integration tests are currently failing due to too many script compilations. The exact error message is:

`{"error":{"root_cause":[{"type":"circuit_breaking_exception","reason":"[script] Too many dynamic script compilations within, max: [75/5m]; please use indexed, or scripts with parameters instead; this limit can be changed by the [script.context.field.max_compilations_rate] setting","bytes_wanted":0,"bytes_limit":0,"durability":"TRANSIENT"}],"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":"elasticsearch-sql_test_index_account","node":"sM9eduqeRKOVqk7JbU0zIA","reason":{"type":"general_script_exception","reason":"Failed to compile inline script [def if_1 = 0;return if_1;] using lang [painless]","caused_by":{"type":"circuit_breaking_exception","reason":"[script] Too many dynamic script compilations within, max: [75/5m]; please use indexed, or scripts with parameters instead; this limit can be changed by the [script.context.field.max_compilations_rate] setting","bytes_wanted":0,"bytes_limit":0,"durability":"TRANSIENT"}}}],"caused_by":{"type":"circuit_breaking_exception","reason":"[script] Too many dynamic script compilations within, max: [75/5m]; please use indexed, or scripts with parameters instead; this limit can be changed by the [script.context.field.max_compilations_rate] setting","bytes_wanted":0,"bytes_limit":0,"durability":"TRANSIENT"}},"status":500}`

See https://github.com/opendistro-for-elasticsearch/opendistro-build/runs/1058066143 for an example failure.

### Description of changes:
This change updates setup_runners_service.sh to append a line to `elasticsearch.yml` which increases the script compilation rate limit to 1000 per minute.

### Test Results:
- Created a docker image with the ODFE 1.10.0 staging deb installed (manually reproduced what the setup_runners_service.sh script does).
- Ran the SQL plugin integ tests to reproduce the problem.
- Manually updated elasticsearch.yml with the new config line and restarted the server.
- Re-ran the SQL plugin integ tests. Verified that the rate limit is no longer exceeded.
- Smoke test of the script works: https://github.com/opendistro-for-elasticsearch/opendistro-build/runs/1062936008. The with-security tests are failing for an unrelated reason (can't find the certificate).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
