### PR TITLE
 Fix Incorrect Kibana URL in Windows Service Scripts

### DIFF
--- a/.github/scripts/setup_runners_service_windows.ps1
+++ b/.github/scripts/setup_runners_service_windows.ps1
@@ -105,7 +105,7 @@ if ($SETUP_ACTION -eq "--kibana" -Or $SETUP_ACTION -eq "--kibana-nosec"){
   mkdir kibana-it-test
   cd kibana-it-test
   $S3_KIBANA_PACKAGE="odfe-"+$OD_VERSION+"-kibana.zip"
-  aws s3 cp --quiet s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/ode-windows-zip/$S3_KIBANA_PACKAGE . --quiet; echo $?\
+  aws s3 cp --quiet s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/staging/odfe-window-zip/$S3_KIBANA_PACKAGE . --quiet; echo $?\
   unzip -qq .\$S3_KIBANA_PACKAGE
 }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/opendistro-infra/issues/251

*Description of changes:*
This PR is to fix an incorrect kibana url for windows version in service powershell script.

*Test Results:*
https://github.com/opendistro-for-elasticsearch/opendistro-build/runs/1064392251?check_suite_focus=true#step:5:130
The test is supposed to fail, it only test to prove kibana started as download is complete with the fixed URL.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
