### PR TITLE
Update PR template to ask user for Helm documentation updates when needed

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,4 +4,6 @@
 
 *Test Results:*
 
+**Note: If this PR is related to HELM, please also update the README for related documentation changes. Thanks.**
+
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,6 @@
 
 *Test Results:*
 
-**Note: If this PR is related to HELM, please also update the README for related documentation changes. Thanks.**
+**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,6 @@
 *Test Results:*
 
 **Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
+**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/opendistro-infra/issues/251

*Description of changes:*
This PR is to update PR template to ask user for HELM documentation updates when needed

*Test Results:*
Not Needed as it is a PR template update

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
