### PR TITLE
Correct alerting integTest to use alerting repository

### DIFF
--- a/.github/workflows/staging-build-windows.yml
+++ b/.github/workflows/staging-build-windows.yml
@@ -258,7 +258,7 @@ jobs:
 
       - uses: actions/checkout@v1
         with:
-            repository: opendistro-for-elasticsearch/sql
+            repository: opendistro-for-elasticsearch/alerting
             ref: ${{env.p_tag_alerting}}
 
       - name: Configure AWS Credentials


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/opendistro-infra/issues/251

*Description of changes:*
This PR is to correct alerting integTest to use alerting repository

*Test Results:*
No Need as it is just a repo correction, no function changes

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
