### PR TITLE
Add new cookie settings for security kibana plugins 2.0 framework when https is disabled

### DIFF
--- a/kibana/docker/build/kibana/config/kibana.yml
+++ b/kibana/docker/build/kibana/config/kibana.yml
@@ -27,6 +27,9 @@ opendistro_security.multitenancy.enabled: true
 opendistro_security.multitenancy.tenants.preferred: ["Private", "Global"]
 opendistro_security.readonly_mode.roles: ["kibana_read_only"]
 
+# Use this setting if you are running kibana without https
+opendistro_security.cookie.secure: false
+
 newsfeed.enabled: false
 telemetry.optIn: false
 telemetry.enabled: false

--- a/kibana/linux_distributions/config/kibana.yml
+++ b/kibana/linux_distributions/config/kibana.yml
@@ -24,6 +24,9 @@ opendistro_security.multitenancy.enabled: true
 opendistro_security.multitenancy.tenants.preferred: ["Private", "Global"]
 opendistro_security.readonly_mode.roles: ["kibana_read_only"]
 
+# Use this setting if you are running kibana without https
+opendistro_security.cookie.secure: false
+
 newsfeed.enabled: false
 telemetry.optIn: false
 telemetry.enabled: false


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/opendistro-infra/issues/251

*Description of changes:*
This PR is to add new cookie settings for security kibana plugins 2.0 framework when https is disabled
The 2.0 framework is forcing 1 to 1 match between https and cookie settings
Our kibana is default to http, thus requires cookie to be insecure
Users can choose to enable https and disable this config

$ find . -name kibana.yml
./kibana/docker/build/kibana/config/kibana.yml
./kibana/linux_distributions/config/kibana.yml

*Test Results:*
Manually tested on a EC2 instance, no automatic test yet.


**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
