### PR TITLE
Add opendistro_security.cookie.secure: false to service scripts settings for TAR/DEB/RPM/DOCKER/WINDOWS

### DIFF
--- a/.github/scripts/setup_runners_service.sh
+++ b/.github/scripts/setup_runners_service.sh
@@ -220,13 +220,16 @@ then
     mkdir -p $KIBANA_ROOT
     aws s3 cp s3://$S3_BUCKET/downloads/tarball/$KIBANA_PACKAGE_NAME/$KIBANA_PACKAGE_NAME-$OD_VERSION.tar.gz . --quiet; echo $?
     tar -zxf $KIBANA_PACKAGE_NAME-$OD_VERSION.tar.gz -C $KIBANA_ROOT --strip-components 1
+    echo "opendistro_security.cookie.secure: false" >> $KIBANA_ROOT/config/kibana.yml
   elif [ "$SETUP_DISTRO" = "docker" ]
   then
     echo "FROM opendistroforelasticsearch/opendistroforelasticsearch-kibana:$OD_VERSION" >> Dockerfile.kibana
+    echo "RUN echo 'opendistro_security.cookie.secure: false' >> /usr/share/kibana/config/kibana.yml" >> Dockerfile.kibana
     docker build -t odfe-kibana-http:security -f Dockerfile.kibana .
     sleep 5
   else
     sudo apt install $KIBANA_PACKAGE_NAME=$OD_VERSION* -y || sudo yum install $KIBANA_PACKAGE_NAME-$OD_VERSION -y
+    sudo echo "opendistro_security.cookie.secure: false" >> /etc/kibana/kibana.yml
   fi
 fi
 

--- a/.github/scripts/setup_runners_service_windows.ps1
+++ b/.github/scripts/setup_runners_service_windows.ps1
@@ -107,6 +107,7 @@ if ($SETUP_ACTION -eq "--kibana" -Or $SETUP_ACTION -eq "--kibana-nosec"){
   $S3_KIBANA_PACKAGE="odfe-"+$OD_VERSION+"-kibana.zip"
   aws s3 cp --quiet s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/staging/odfe-window-zip/$S3_KIBANA_PACKAGE . --quiet; echo $?\
   unzip -qq .\$S3_KIBANA_PACKAGE
+  echo "opendistro_security.cookie.secure: false" >> opendistroforelasticsearch-kibana\config\kibana.yml
 }
 
 if ($SETUP_ACTION -eq "--kibana"){


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/opendistro-infra/issues/251

*Description of changes:*
Add opendistro_security.cookie.secure: false to service scripts settings for TAR/DEB/RPM/DOCKER/WINDOWS
This is a follow-up PR to https://github.com/opendistro-for-elasticsearch/opendistro-build/pull/397
Service script will add this settings no matter what
It will not take effect in security kibana 1.0 framework, and it will take effects if it does not present in security kibana 2.0 framework

*Test Results:*
No way to test as integration test does not allow us to access 5601 port on github runners

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
