### PR TITLE
Revert "Add opendistro_security.cookie.secure: false to service scripts settings for TAR/DEB/RPM/DOCKER/WINDOWS"

### DIFF
--- a/.github/scripts/setup_runners_service.sh
+++ b/.github/scripts/setup_runners_service.sh
@@ -220,16 +220,13 @@ then
     mkdir -p $KIBANA_ROOT
     aws s3 cp s3://$S3_BUCKET/downloads/tarball/$KIBANA_PACKAGE_NAME/$KIBANA_PACKAGE_NAME-$OD_VERSION.tar.gz . --quiet; echo $?
     tar -zxf $KIBANA_PACKAGE_NAME-$OD_VERSION.tar.gz -C $KIBANA_ROOT --strip-components 1
-    echo "opendistro_security.cookie.secure: false" >> $KIBANA_ROOT/config/kibana.yml
   elif [ "$SETUP_DISTRO" = "docker" ]
   then
     echo "FROM opendistroforelasticsearch/opendistroforelasticsearch-kibana:$OD_VERSION" >> Dockerfile.kibana
-    echo "RUN echo 'opendistro_security.cookie.secure: false' >> /usr/share/kibana/config/kibana.yml" >> Dockerfile.kibana
     docker build -t odfe-kibana-http:security -f Dockerfile.kibana .
     sleep 5
   else
     sudo apt install $KIBANA_PACKAGE_NAME=$OD_VERSION* -y || sudo yum install $KIBANA_PACKAGE_NAME-$OD_VERSION -y
-    sudo echo "opendistro_security.cookie.secure: false" >> /etc/kibana/kibana.yml
   fi
 fi
 

--- a/.github/scripts/setup_runners_service_windows.ps1
+++ b/.github/scripts/setup_runners_service_windows.ps1
@@ -107,7 +107,6 @@ if ($SETUP_ACTION -eq "--kibana" -Or $SETUP_ACTION -eq "--kibana-nosec"){
   $S3_KIBANA_PACKAGE="odfe-"+$OD_VERSION+"-kibana.zip"
   aws s3 cp --quiet s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/odfe-windows/staging/odfe-window-zip/$S3_KIBANA_PACKAGE . --quiet; echo $?\
   unzip -qq .\$S3_KIBANA_PACKAGE
-  echo "opendistro_security.cookie.secure: false" >> opendistroforelasticsearch-kibana\config\kibana.yml
 }
 
 if ($SETUP_ACTION -eq "--kibana"){


### PR DESCRIPTION
Reverts opendistro-for-elasticsearch/opendistro-build#398

It is not required anymore as this is already a default in #397, and adding it for the second time will cause issues:

```
FATAL CLI ERROR YAMLException: duplicated mapping key at line 36, column 1:
```