### PR TITLE
Make check-version-update logs less verbose

### DIFF
--- a/.github/workflows/check-version-upgrade.yml
+++ b/.github/workflows/check-version-upgrade.yml
@@ -45,7 +45,7 @@ jobs:
             sudo sysctl -w vm.max_map_count=262144
             wget -qO - https://d3g5vo6xdbdb9a.cloudfront.net/GPG-KEY-opendistroforelasticsearch | sudo apt-key add -
             echo "deb https://d3g5vo6xdbdb9a.cloudfront.net/apt stable main" | sudo tee -a   /etc/apt/sources.list.d/opendistroforelasticsearch.list
-            wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$prev_es_version-amd64.deb
+            wget -q https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$prev_es_version-amd64.deb
             sudo dpkg -i elasticsearch-oss-$prev_es_version-amd64.deb
             sudo apt-get update -y
             sudo apt install opendistroforelasticsearch -y
@@ -60,7 +60,7 @@ jobs:
             set +e
             sudo systemctl stop elasticsearch.service
             es_version=`./bin/version-info --es`
-            wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$es_version-amd64.deb
+            wget -q https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-$es_version-amd64.deb
             sudo dpkg -i elasticsearch-oss-$es_version-amd64.deb
             echo "deb https://d3g5vo6xdbdb9a.cloudfront.net/staging/apt stable main" | sudo tee -a /etc/apt/sources.list.d/opendistroforelasticsearch.list
             sudo apt-get update


### PR DESCRIPTION
*Description of changes:*
Tell wget to run in quiet mode

*Test Results:*
Workflow succeeded and has ~4500 fewer log lines: https://github.com/opendistro-for-elasticsearch/opendistro-build/runs/1184349997?check_suite_focus=true

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
