### PR TITLE
Update opendistro-for-elasticsearch-release-notes-1.10.1.md to label kibana cookie change as a breaking change and link instruction page to users

### DIFF
--- a/release-notes/opendistro-for-elasticsearch-release-notes-1.10.1.md
+++ b/release-notes/opendistro-for-elasticsearch-release-notes-1.10.1.md
@@ -22,7 +22,7 @@ Open Distro for Elasticsearch 1.10.1 includes the following features, enhancemen
 ### Release Engineering
 
 * Kibana has new cookie settings for security Kibana plugin 2.0 framework ([#397](https://github.com/opendistro-for-elasticsearch/opendistro-build/pull/397))
-  Please follow the instructions [here](https://opendistro.github.io/for-elasticsearch-docs/docs/upgrade/1-10-1/) if you are upgrading from previous Kibana versions to 1.10.1.
+  Please follow the instructions [to upgrade Open Distro Kibana to 1.10.1](https://opendistro.github.io/for-elasticsearch-docs/docs/upgrade/1-10-1/) if you are upgrading from previous Kibana versions to 1.10.1.
 
 ## FEATURES
 

--- a/release-notes/opendistro-for-elasticsearch-release-notes-1.10.1.md
+++ b/release-notes/opendistro-for-elasticsearch-release-notes-1.10.1.md
@@ -17,6 +17,12 @@ The release consists of Apache 2 licensed Elasticsearch version 7.9.1, and Kiban
 
 Open Distro for Elasticsearch 1.10.1 includes the following features, enhancements, bug fixes, infrastructure, documentation, maintenance, and refactoring updates.
 
+## BREAKING CHANGES
+
+### Release Engineering
+
+* Kibana has new cookie settings for security Kibana plugin 2.0 framework ([#397](https://github.com/opendistro-for-elasticsearch/opendistro-build/pull/397))
+  Please follow the instructions [here](https://opendistro.github.io/for-elasticsearch-docs/docs/upgrade/1-10-1/) if you are upgrading from previous Kibana versions to 1.10.1.
 
 ## FEATURES
 
@@ -432,10 +438,6 @@ Open Distro for Elasticsearch 1.10.1 includes the following features, enhancemen
 
 * Build against Elasticsearch 7.9 ([#56](https://github.com/opendistro-for-elasticsearch/perftop/pull/56))
 * Build against Elasticsearch 7.9.1 ([#59](https://github.com/opendistro-for-elasticsearch/perftop/pull/59))
-
-### Release Engineering
-
-* Kibana has new cookie settings for security Kibana plugin 2.0 framework ([#397](https://github.com/opendistro-for-elasticsearch/opendistro-build/pull/397))
 
 ### Security
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro/for-elasticsearch-docs/pull/312

*Description of changes:*
Update opendistro-for-elasticsearch-release-notes-1.10.1.md to label kibana cookie change as a breaking change and link instruction page to users

*Test Results:*

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
