### PR TITLE
Activate cronjob to get alerts regarding plugin availability

### DIFF
--- a/.github/workflows/check-plugin.yml
+++ b/.github/workflows/check-plugin.yml
@@ -2,7 +2,8 @@ name: Check Plugin Availability Main
 
 on:
   schedule:
-   - cron: '0 0,15 * * *'
+    - cron: '0 0,15 * * *'
+
   repository_dispatch:
     types: [check-plugin]
 

--- a/.github/workflows/check-plugin.yml
+++ b/.github/workflows/check-plugin.yml
@@ -1,8 +1,8 @@
 name: Check Plugin Availability Main
 
 on:
-  #schedule:
-  #  - cron: '0 0,15 * * *'
+  schedule:
+   - cron: '0 0,15 * * *'
   repository_dispatch:
     types: [check-plugin]
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Activate cron job to get alerts regarding plugin availability as this is release time. This will send alerts to slack room
*Test Results:*
Not required. Just activating the scheduled cron job

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
