### PR TITLE
Lock plugin versions for 1.11.0 and add kibana-notebooks

### DIFF
--- a/bin/plugins.json
+++ b/bin/plugins.json
@@ -5,7 +5,7 @@
     "deb": "opendistro-sql/opendistro-sql",
     "rpm": "opendistro-sql/opendistro-sql",
     "windows": "opendistro-sql/opendistro_sql",
-    "cutversion": "1.10.1.1",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "elasticsearch"
   },
@@ -15,7 +15,7 @@
     "deb": "opendistro-alerting/opendistro-alerting",
     "rpm": "opendistro-alerting/opendistro-alerting",
     "windows": "opendistro-alerting/opendistro_alerting",
-    "cutversion": "1.10.1.2",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "elasticsearch"
   },
@@ -25,7 +25,7 @@
     "deb": "opendistro-job-scheduler/opendistro-job-scheduler",
     "rpm": "opendistro-job-scheduler/opendistro-job-scheduler",
     "windows": "opendistro-job-scheduler/opendistro-job-scheduler",
-    "cutversion": "1.10.1.0",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "elasticsearch"
   },
@@ -35,7 +35,7 @@
     "deb": "opendistro-security/opendistro-security",
     "rpm": "opendistro-security/opendistro-security",
     "windows": "opendistro-security/opendistro_security",
-    "cutversion": "1.10.1.0",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "elasticsearch"
   },
@@ -45,7 +45,7 @@
     "deb": "opendistro-performance-analyzer/opendistro-performance-analyzer",
     "rpm": "opendistro-performance-analyzer/opendistro-performance-analyzer",
     "windows": "none",
-    "cutversion": "1.10.1.0",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "elasticsearch"
   },
@@ -55,7 +55,7 @@
     "deb": "opendistro-index-management/opendistro-index-management",
     "rpm": "opendistro-index-management/opendistro-index-management",
     "windows": "opendistro-index-management/opendistro_index_management",
-    "cutversion": "1.10.1.1",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "elasticsearch"
   },
@@ -65,7 +65,7 @@
     "deb": "opendistro-knn/opendistro-knn",
     "rpm": "opendistro-knn/opendistro-knn",
     "windows": "none",
-    "cutversion": "1.10.1.0",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "elasticsearch"
   },
@@ -75,7 +75,7 @@
     "deb": "opendistro-knnlib/opendistro-knnlib",
     "rpm": "opendistro-knnlib/opendistro-knnlib",
     "windows": "none",
-    "cutversion": "1.10.1.0",
+    "cutversion": "1.11.0.0",
     "require_install": "false",
     "category": "elasticsearch"
   },
@@ -85,17 +85,17 @@
     "deb": "opendistro-anomaly-detection/opendistro-anomaly-detection",
     "rpm": "opendistro-anomaly-detection/opendistro-anomaly-detection",
     "windows": "opendistro-anomaly-detection/opendistro-anomaly-detection",
-    "cutversion": "1.10.1.0",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "elasticsearch"
   },
   "sql-workbench": {
     "git": "opendistro-for-elasticsearch/sql",
-    "zip": "opendistro-sql-workbench/opendistro-sql-workbench",
+    "zip": "opendistro-query-workbench/opendistro-query-workbench",
     "deb": "none",
     "rpm": "none",
     "windows": "none",
-    "cutversion": "1.10.1.1",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "kibana"
   },
@@ -105,7 +105,7 @@
     "deb": "none",
     "rpm": "none",
     "windows": "none",
-    "cutversion": "1.10.1.0",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "kibana"
   },
@@ -115,7 +115,7 @@
     "deb": "none",
     "rpm": "none",
     "windows": "none",
-    "cutversion": "1.10.1.1",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "kibana"
   },
@@ -125,7 +125,7 @@
     "deb": "none",
     "rpm": "none",
     "windows": "none",
-    "cutversion": "1.10.1.1",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "kibana"
   },
@@ -135,7 +135,17 @@
     "deb": "none",
     "rpm": "none",
     "windows": "none",
-    "cutversion": "1.10.1.0",
+    "cutversion": "1.11.0.0",
+    "require_install": "true",
+    "category": "kibana"
+  },
+  "notebooks-kibana": {
+    "git": "opendistro-for-elasticsearch/kibana-notebooks",
+    "zip": "opendistro-notebooks/opendistro-notebooks-kibana",
+    "deb": "none",
+    "rpm": "none",
+    "windows": "none",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "kibana"
   },
@@ -145,7 +155,7 @@
     "deb": "none",
     "rpm": "none",
     "windows": "none",
-    "cutversion": "1.10.1.1",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "client"
   },
@@ -155,7 +165,7 @@
     "deb": "none",
     "rpm": "none",
     "windows": "none",
-    "cutversion": "1.10.1.1",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "client"
   },
@@ -165,7 +175,7 @@
     "deb": "none",
     "rpm": "none",
     "windows": "none",
-    "cutversion": "1.10.1.1",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "client"
   },
@@ -175,7 +185,7 @@
     "deb": "none",
     "rpm": "none",
     "windows": "none",
-    "cutversion": "1.10.1.1",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "client"
   },
@@ -185,7 +195,7 @@
     "deb": "none",
     "rpm": "none",
     "windows": "none",
-    "cutversion": "1.10.1.1",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "client"
   },
@@ -195,7 +205,7 @@
     "deb": "none",
     "rpm": "none",
     "windows": "none",
-    "cutversion": "1.10.1.0",
+    "cutversion": "1.11.0.0",
     "require_install": "true",
     "category": "perftop"
   }

--- a/bin/version.json
+++ b/bin/version.json
@@ -10,6 +10,6 @@
     "next": "1.11.1"
   },
   "versionCut": {
-    "is_cut": "false"
+    "is_cut": "true"
   }
 }


### PR DESCRIPTION
*Description of changes:*
Lock plugin versions for ODFE 1.11.0. Also add kibana-notebooks and change sql-workbench to query-workbench.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
