### PR TITLE
Disable plugin availability bot

### DIFF
--- a/.github/workflows/check-plugin.yml
+++ b/.github/workflows/check-plugin.yml
@@ -1,8 +1,8 @@
 name: Check Plugin Availability Main
 
 on:
-  schedule:
-    - cron: '0 0,15 * * *'
+#  schedule:
+#    - cron: '0 0,15 * * *'
 
   repository_dispatch:
     types: [check-plugin]


### PR DESCRIPTION
*Description of changes:*
Disable plugin availability check cron

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
