### PR TITLE
Update staging workflows to use workbench instead of sql-workbench

### DIFF
--- a/.github/workflows/staging-build-deb.yml
+++ b/.github/workflows/staging-build-deb.yml
@@ -547,9 +547,9 @@ jobs:
       - name: Bootstrap the plugin
         run: |
           cd ./kibana/plugins
-          cp -rp sql/sql-workbench .
+          cp -rp sql/workbench .
           rm -rf sql/
-          cd sql-workbench
+          cd workbench
 
       - name: Retry the bootstraps
         # sql repo has a bug that you have to bootstrap at least twice to success
@@ -559,7 +559,7 @@ jobs:
           # 60 min timeouts as certain runners like windows may take 30+ min just to complete one bootstrap
           timeout_minutes: 60
           max_attempts: 3
-          command: cd ./kibana/plugins/sql-workbench; pwd; yarn kbn bootstrap
+          command: cd ./kibana/plugins/workbench; pwd; yarn kbn bootstrap
 
       - name: Start ES and Kibana
         run: |
@@ -571,7 +571,7 @@ jobs:
       - name: run IT
         uses: cypress-io/github-action@v1
         with:
-          working-directory: kibana/plugins/sql-workbench
+          working-directory: kibana/plugins/workbench
           command: npx cypress run
 
   Test-AD-KIBANA:

--- a/.github/workflows/staging-build-docker.yml
+++ b/.github/workflows/staging-build-docker.yml
@@ -508,9 +508,9 @@ jobs:
       - name: Bootstrap the plugin
         run: |
           cd ./kibana/plugins
-          cp -rp sql/sql-workbench .
+          cp -rp sql/workbench .
           rm -rf sql/
-          cd sql-workbench
+          cd workbench
 
       - name: Retry the bootstraps
         # sql repo has a bug that you have to bootstrap at least twice to success
@@ -520,7 +520,7 @@ jobs:
           # 60 min timeouts as certain runners like windows may take 30+ min just to complete one bootstrap
           timeout_minutes: 60
           max_attempts: 3
-          command: cd ./kibana/plugins/sql-workbench; pwd; yarn kbn bootstrap
+          command: cd ./kibana/plugins/workbench; pwd; yarn kbn bootstrap
 
       - name: Start ES and Kibana
         run: |
@@ -532,7 +532,7 @@ jobs:
       - name: run IT
         uses: cypress-io/github-action@v1
         with:
-          working-directory: kibana/plugins/sql-workbench
+          working-directory: kibana/plugins/workbench
           command: npx cypress run
 
   Test-AD-Kibana:

--- a/.github/workflows/staging-build-rpm.yml
+++ b/.github/workflows/staging-build-rpm.yml
@@ -488,9 +488,9 @@ jobs:
       - name: Bootstrap the plugin
         run: |
           cd ./kibana/plugins
-          cp -rp sql/sql-workbench .
+          cp -rp sql/workbench .
           rm -rf sql/
-          cd sql-workbench
+          cd workbench
 
       - name: Retry the bootstraps
         # sql repo has a bug that you have to bootstrap at least twice to success
@@ -500,7 +500,7 @@ jobs:
           # 60 min timeouts as certain runners like windows may take 30+ min just to complete one bootstrap
           timeout_minutes: 60
           max_attempts: 3
-          command: cd ./kibana/plugins/sql-workbench; pwd; yarn kbn bootstrap
+          command: cd ./kibana/plugins/workbench; pwd; yarn kbn bootstrap
 
       - name: Start ES and Kibana
         run: |
@@ -512,7 +512,7 @@ jobs:
       - name: run IT
         uses: cypress-io/github-action@v1
         with:
-          working-directory: kibana/plugins/sql-workbench
+          working-directory: kibana/plugins/workbench
           command: npx cypress run
           
   Test-AD-KIBANA:

--- a/.github/workflows/staging-build-tar.yml
+++ b/.github/workflows/staging-build-tar.yml
@@ -458,9 +458,9 @@ jobs:
       - name: Bootstrap the plugin
         run: |
           cd ./kibana/plugins
-          cp -rp sql/sql-workbench .
+          cp -rp sql/workbench .
           rm -rf sql/
-          cd sql-workbench
+          cd workbench
 
       - name: Retry the bootstraps
         # sql repo has a bug that you have to bootstrap at least twice to success
@@ -470,7 +470,7 @@ jobs:
           # 60 min timeouts as certain runners like windows may take 30+ min just to complete one bootstrap
           timeout_minutes: 60
           max_attempts: 3
-          command: cd ./kibana/plugins/sql-workbench; pwd; yarn kbn bootstrap
+          command: cd ./kibana/plugins/workbench; pwd; yarn kbn bootstrap
 
       - name: Start ES and Kibana
         run: |
@@ -482,7 +482,7 @@ jobs:
       - name: run IT
         uses: cypress-io/github-action@v1
         with:
-          working-directory: kibana/plugins/sql-workbench
+          working-directory: kibana/plugins/workbench
           command: npx cypress run
 
   Test-AD-KIBANA:

--- a/.github/workflows/staging-build-windows.yml
+++ b/.github/workflows/staging-build-windows.yml
@@ -451,9 +451,9 @@ jobs:
       - name: Bootstrap the plugin
         run: |
           cd ./kibana/plugins
-          cp -rp sql/sql-workbench .
+          cp -rp sql/workbench .
           rm -rf sql/
-          cd sql-workbench
+          cd workbench
         shell: bash
 
       - name: Retry the bootstraps
@@ -465,7 +465,7 @@ jobs:
           timeout_minutes: 60
           max_attempts: 3
           # We have to use "&&" in pwsh as ";" does not work here
-          command: cd ./kibana/plugins/sql-workbench && dir && yarn kbn bootstrap
+          command: cd ./kibana/plugins/workbench && dir && yarn kbn bootstrap
 
       - name: run ES and kibana and IT (RUN IN ONE STEP OR WINDOWS BREAK)
         run: |
@@ -475,7 +475,7 @@ jobs:
           curl -s https://raw.githubusercontent.com/opendistro-for-elasticsearch/sql/master/integ-test/src/test/resources/accounts.json | curl -s -H 'Content-Type: application/x-ndjson' -XPOST 'localhost:9200/accounts/_bulk?pretty' --data-binary "@-" > $null 2>&1
           curl -s https://raw.githubusercontent.com/opendistro-for-elasticsearch/sql/master/integ-test/src/test/resources/employee_nested.json | curl -s -H 'Content-Type: application/x-ndjson' -XPOST 'localhost:9200/employee_nested/_bulk?pretty' --data-binary "@-" > $null 2>&1
           dir
-          cd ./kibana/plugins/sql-workbench
+          cd ./kibana/plugins/workbench
           npx cypress run
   
   Test-AD-KIBANA:


### PR DESCRIPTION
*Description of changes:*
sql-workbench has been renamed to workbench

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
