### PR TITLE
Remove Java 15 from the test matrix

### DIFF
--- a/.github/workflows/staging-build-deb.yml
+++ b/.github/workflows/staging-build-deb.yml
@@ -188,7 +188,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
 
@@ -219,7 +219,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
 
@@ -249,7 +249,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
 
@@ -279,7 +279,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       - name: Retrieve plugin tags 
@@ -305,7 +305,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
 
@@ -335,7 +335,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
 
@@ -365,7 +365,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
 
@@ -396,7 +396,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
 
@@ -426,7 +426,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
 
@@ -493,7 +493,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       - name: Set up AWS Cred
@@ -581,7 +581,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/staging-build-docker.yml
+++ b/.github/workflows/staging-build-docker.yml
@@ -150,7 +150,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
 
@@ -181,7 +181,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
 
@@ -211,7 +211,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
 
@@ -241,7 +241,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       - name: Retrieve plugin tags 
@@ -267,7 +267,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
 
@@ -297,7 +297,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
 
@@ -327,7 +327,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
 
@@ -357,7 +357,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
 
@@ -387,7 +387,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       
@@ -454,7 +454,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       - name: Set up AWS Cred
@@ -542,7 +542,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       

--- a/.github/workflows/staging-build-tar.yml
+++ b/.github/workflows/staging-build-tar.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - name: Set up AWS Cred
         uses: aws-actions/configure-aws-credentials@v1
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - name: Set up AWS Cred
         uses: aws-actions/configure-aws-credentials@v1
@@ -130,7 +130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - name: Set up AWS Cred
         uses: aws-actions/configure-aws-credentials@v1
@@ -163,7 +163,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - name: Set up AWS Cred
         uses: aws-actions/configure-aws-credentials@v1
@@ -196,7 +196,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - name: Set up AWS Cred
         uses: aws-actions/configure-aws-credentials@v1
@@ -229,7 +229,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - name: Set up AWS Cred
         uses: aws-actions/configure-aws-credentials@v1
@@ -262,7 +262,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - name: Set up AWS Cred
         uses: aws-actions/configure-aws-credentials@v1
@@ -295,7 +295,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       - name: Set up AWS Cred
@@ -332,7 +332,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       - name: Set up AWS Cred
@@ -404,7 +404,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       - name: Set up AWS Cred
@@ -492,7 +492,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       - name: Set up AWS Cred

--- a/.github/workflows/staging-build-windows.yml
+++ b/.github/workflows/staging-build-windows.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       - name: Retrieve plugin tags
@@ -93,7 +93,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       - name: Retrieve plugin tags
@@ -130,7 +130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       - name: Retrieve plugin tags
@@ -167,7 +167,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       - name: Retrieve plugin tags
@@ -204,7 +204,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       - name: Retrieve plugin tags
@@ -241,7 +241,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       - name: Retrieve plugin tags
@@ -277,7 +277,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       - name: Retrieve plugin tags
@@ -318,7 +318,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       - name: Configure AWS Credentials
@@ -394,7 +394,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       - name: Set up AWS Cred
@@ -485,7 +485,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [14, 15]
+        java: [14]
     steps:
       - uses: actions/checkout@v1
       - name: Configure AWS Credentials


### PR DESCRIPTION
We don't need Java 15 for the 1.11.0 release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
