### PR TITLE
Fix max_compilations_rate setting for deb/rpm tests

### DIFF
--- a/.github/scripts/setup_runners_service.sh
+++ b/.github/scripts/setup_runners_service.sh
@@ -131,7 +131,7 @@ else
   sudo sed -i '/path.logs/a path.repo: ["/home/repo"]' /etc/elasticsearch/elasticsearch.yml
   sudo sed -i /^node.max_local_storage_nodes/d /etc/elasticsearch/elasticsearch.yml
   # Increase the number of allowed script compilations. The SQL integ tests use a lot of scripts.
-  sudo echo "script.context.field.max_compilations_rate: 1000/1m" >> /etc/elasticsearch/elasticsearch.yml
+  sudo echo "script.context.field.max_compilations_rate: 1000/1m" | sudo tee -a /etc/elasticsearch/elasticsearch.yml > /dev/null
 fi
 
 if [ "$SETUP_ACTION" = "--es" ]


### PR DESCRIPTION
*Description of changes:*
The line in setup_runners_service.sh that added the max_compilations_rate was failing with "permission denied". This change fixes the issue.

I will add a follow-up PR that adds `set -e` so that these issues are caught sooner. There are a bunch of things that fail right now if I add `set -e`, so I'm not including it in this change.

*Test Results:*
Manually verified that the elasticsearch.yml file is correctly updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
