### PR TITLE
Remove the ODFE Repos which are not need to be scanned for vulnerability 

### DIFF
--- a/standalone-tools/wss-scan.config
+++ b/standalone-tools/wss-scan.config
@@ -1,3 +1,3 @@
 baseDirPath=$(pwd)
 gitBasePath=https://github.com/opendistro-for-elasticsearch/
-gitRepos=alerting,simple-ingest-transformation-utility-pipeline,opendistro-build,security,performance-analyzer-rca,anomaly-detection,index-management,security-kibana-plugin,sql,job-scheduler,kibana-reports,notifications,performance-analyzer,index-management-kibana-plugin,alerting-kibana-plugin,common-utils,k-NN,anomaly-detection-kibana-plugin,perftop,kibana-notebooks,sql-workbench,sql-cli,sql-jdbc,sql-odbc,piped-processing-language
+gitRepos=alerting,simple-ingest-transformation-utility-pipeline,opendistro-build,security,performance-analyzer-rca,anomaly-detection,index-management,security-kibana-plugin,sql,job-scheduler,notifications,performance-analyzer,index-management-kibana-plugin,alerting-kibana-plugin,common-utils,k-NN,anomaly-detection-kibana-plugin,perftop,kibana-notebooks,piped-processing-language


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Remove the sql plugin which have been combined to a single repo and also remove kibana-reports repo from the wss-scan.config

*Test Results:*
No Test needed

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
