### PR TITLE
Releasenotes.sh: Explicitly tell 'seq' to count down

### DIFF
--- a/bin/releasenotes.sh
+++ b/bin/releasenotes.sh
@@ -87,7 +87,7 @@ do
     entry_upper=`echo $entry_upper | sed -E 's/^#//g'`
 
     # Loop through the actual release notes lines in reverse order so they appear in normal order on distro release notes
-    for index in `seq $(echo ${#entry_notes_array[@]}) 0`
+    for index in `seq $(echo ${#entry_notes_array[@]}) -1 0`
     do
       # As a limitation in MacOS / BSD version of sed, we can only insert one line at a time
       # Ignore usage of in-place parameter as there are differences between BSD/MacOS sed and GNU sed commands


### PR DESCRIPTION
GNU seq defaults to a positive increment, even when 'last' is smaller than 'first'

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
