### PR TITLE
Improve releasenotes.sh to properly escape ampersand in release notes

### DIFF
--- a/bin/releasenotes.sh
+++ b/bin/releasenotes.sh
@@ -92,7 +92,7 @@ do
     entry_upper=`echo $entry_upper | sed -E 's/^#//g'`
 
     # Loop through the actual release notes lines in reverse order so they appear in normal order on distro release notes
-    for index in `seq $(echo ${#entry_notes_array[@]}) 0`
+    for index in `seq $(echo ${#entry_notes_array[@]}) -1 0`
     do
       # As a limitation in MacOS / BSD version of sed, we can only insert one line at a time
       # Ignore usage of in-place parameter as there are differences between BSD/MacOS sed and GNU sed commands


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
This PR is to properly escape the & ampersand in release notes
It also change wget output from none to limited verbose so at least user can see what is wrong with the retrieving of release notes from GitHub here.

*Test Results:*
None

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
