### PR TITLE
Change the Vulnerability workflow to run on ec2 

### DIFF
--- a/.github/workflows/check-vulnerability-whitesource.yml
+++ b/.github/workflows/check-vulnerability-whitesource.yml
@@ -6,11 +6,30 @@ on:
   repository_dispatch:
     types: [check-vulnerability-whitesource]
 
+
 jobs:
-  whitesource-vulnerability-scan:
-    name: WhiteSource Vulnerability Scan
+  Provision-Runners:
+    name: Provision-Runners
     runs-on: ubuntu-18.04
-    timeout-minutes: 140
+    steps:
+      - uses: actions/checkout@v1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_EC2_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_EC2_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: AWS Cli Processing
+        run: |
+          RUNNERS="odfe-wss-scan"
+          .github/scripts/setup_runners.sh run $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }}
+
+  whitesource-vulnerability-scan:
+    needs: [Provision-Runners]
+    name: WhiteSource Vulnerability Scan
+    runs-on: [self-hosted, Linux, X64, odfe-wss-scan]
+    outputs:
+      mail_content_output: ${{ steps.vulnerability_scan.outputs.mail_content }}
     strategy:
       fail-fast: false
       matrix:
@@ -21,29 +40,62 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-
       - name: Vulnerability Scan
+        id: vulnerability_scan
         env:
           wss_apikey: ${{ secrets.WSS_API_KEY }}
         run: |
-          cd standalone-tools
-          mvn -v
-          npm -v
-          gradle -v
-          yarn -v
+          export PATH=$JAVA_HOME:$PATH
+          cd standalone-tools ; ls -ltr 
+          sudo yum install -y maven
+          wget -q https://services.gradle.org/distributions/gradle-6.7-bin.zip
+          sudo mkdir /opt/gradle
+          sudo unzip -d /opt/gradle gradle-6.7-bin.zip
+          wget -qO - https://rpm.nodesource.com/setup_14.x | sudo bash -
+          sudo yum install -y nodejs
+          wget -qO - https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
+          sudo rpm --import https://dl.yarnpkg.com/rpm/pubkey.gpg
+          sudo yum install yarn -y
+          export PATH=$PATH:/opt/gradle/gradle-6.7/bin
+          gradle -v; mvn -v ; npm -v; yarn -v
           ./wss-scan.sh
+          echo ::set-output name=mail_content::$(cat output.md)
           cat whitesource/*/*
 
+  Send-Mail:
+    needs: [whitesource-vulnerability-scan]
+    if: always()
+    name: Send Mail
+    runs-on: ubuntu-latest
+    steps:
       - name: Send mail
-        if: ${{ always() }}
         uses: dawidd6/action-send-mail@master
         with:
           server_address: smtp.gmail.com
           server_port: 465
           username: ${{secrets.MAIL_USERNAME}}
           password: ${{secrets.MAIL_PASSWORD}}
-          subject: ODFE Vulnerability and License Scan - Daily Run 
-          body: file://standalone-tools/output.md
+          subject: ODFE Vulnerability and License Scan - Daily Run
+          body: ${{needs.whitesource-vulnerability-scan.outputs.mail_content_output}}
           to: odfe-infra-team@amazon.com,mmakaria@amazon.com
           from: Opendistro Elasticsearch
           content_type: text/html
+
+  CleanUp-Runners:
+    needs: [whitesource-vulnerability-scan]
+    if: always()
+    name: CleanUp-Runners
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_EC2_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_EC2_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: AWS Cli Processing
+        run: |
+          RUNNERS="odfe-wss-scan"
+          .github/scripts/setup_runners.sh terminate $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }}
+

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -14,7 +14,7 @@
 kibana:
   enabled: true
   image: amazon/opendistro-for-elasticsearch-kibana
-  imageTag: 1.11.0
+  imageTag: latest
   ## Specifies the image pull policy. Can be "Always" or "IfNotPresent" or "Never".
   ## Default to "Always".
   imagePullPolicy: ""
@@ -512,7 +512,7 @@ elasticsearch:
   maxMapCount: 262144
 
   image: amazon/opendistro-for-elasticsearch
-  imageTag: 1.11.0
+  imageTag: latest
   ## Specifies the image pull policy. Can be "Always" or "IfNotPresent" or "Never".
   ## Default to "Always".
   imagePullPolicy: ""

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -14,7 +14,7 @@
 kibana:
   enabled: true
   image: amazon/opendistro-for-elasticsearch-kibana
-  imageTag: latest
+  imageTag: 1.11.0
   ## Specifies the image pull policy. Can be "Always" or "IfNotPresent" or "Never".
   ## Default to "Always".
   imagePullPolicy: ""
@@ -512,7 +512,7 @@ elasticsearch:
   maxMapCount: 262144
 
   image: amazon/opendistro-for-elasticsearch
-  imageTag: latest
+  imageTag: 1.11.0
   ## Specifies the image pull policy. Can be "Always" or "IfNotPresent" or "Never".
   ## Default to "Always".
   imagePullPolicy: ""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Change the Vulnerability workflow to run on ec2 , this allows all the child processes to be completed. At present the GitHub runner is unable to complete all the scanning of the ODFE Repos due to less resources. 

*Test Results:*
Scan test result : https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/336617044


**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
