### PR TITLE
[HELM] Elasticsearch: extra containers

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -622,6 +622,7 @@ The following table lists the configurable parameters of the opendistro elastics
 | `elasticsearch.extraVolumes`                              | Array of extra volumes to be added                                                                                                                       | `[]`                                                                    |
 | `elasticsearch.extraVolumeMounts`                         | Array of extra volume mounts to be added                                                                                                                 | `[]`                                                                    |
 | `elasticsearch.extraInitContainers`                       | Array of extra init containers                                                                                                                           | `[]`                                                                    |
+| `elasticsearch.extraContainers`                           | Array of extra containers                                                                                                                                | `[]`                                                                    |
 
 ## Acknowledgements
 * [Kalvin Chau](https://github.com/kalvinnchau) (Software Engineer - Viasat) for all his help with the Kubernetes internals, certs, and debugging

--- a/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -181,6 +181,9 @@ spec:
 {{- if .Values.elasticsearch.extraVolumeMounts }}
 {{ toYaml .Values.elasticsearch.extraVolumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.elasticsearch.extraContainers }}
+{{ toYaml .Values.elasticsearch.extraContainers | indent 6 }}
+{{- end }}
       volumes:
       - name: config
         secret:

--- a/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -189,6 +189,9 @@ spec:
 {{- if .Values.elasticsearch.extraVolumeMounts }}
 {{ toYaml .Values.elasticsearch.extraVolumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.elasticsearch.extraContainers }}
+{{ toYaml .Values.elasticsearch.extraContainers | indent 6 }}
+{{- end }}
       volumes:
       - name: config
         secret:

--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -243,6 +243,9 @@ spec:
 {{- if .Values.elasticsearch.extraVolumeMounts }}
 {{ toYaml .Values.elasticsearch.extraVolumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.elasticsearch.extraContainers }}
+{{ toYaml .Values.elasticsearch.extraContainers | indent 6 }}
+{{- end }}
 {{- if .Values.elasticsearch.master.extraContainers }}
 {{ toYaml .Values.elasticsearch.master.extraContainers | indent 6 }}
 {{- end }}

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -187,6 +187,11 @@ elasticsearch:
   #   image: busybox
   #   command: ['do', 'something']
 
+  extraContainers: []
+  # - name: do-something
+  #   image: busybox
+  #   command: ['do', 'something']
+
   extraVolumes: []
   # - name: extras
   #   emptyDir: {}


### PR DESCRIPTION
*Description of changes:*
User can define extra containers for Elasticsearch

Test Results:

* Deploy using the following chart values :
```
elasticsearch:
  extraContainers:
    - name: extra-container
      image: busybox
      command: ["/bin/bash", "-c", "sleep infinity & wait"]
```
* Check the containers on the Elasticsearch pod

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.