### PR TITLE
Update the AD Integration Test command for build workflows

### DIFF
--- a/.github/workflows/staging-build-deb.yml
+++ b/.github/workflows/staging-build-deb.yml
@@ -330,8 +330,8 @@ jobs:
         run: |
           .github/scripts/setup_runners_service.sh deb --es-nosec
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
-          ./gradlew :integTestRunner --tests "com.amazon.opendistroforelasticsearch.ad.rest.*IT" --tests "com.amazon.opendistroforelasticsearch.ad.e2e.*IT" -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest"
-          
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest"
+
   Test-SQL:
     needs: [sign-deb-artifacts]
     runs-on: [ubuntu-18.04]
@@ -390,8 +390,7 @@ jobs:
         run: |
           .github/scripts/setup_runners_service.sh deb --es
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
-          ./gradlew :integTestRunner --tests "com.amazon.opendistroforelasticsearch.ad.rest.*IT" --tests "com.amazon.opendistroforelasticsearch.ad.e2e.*IT" -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin
-       
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin    
   
   Test-ALERTING:
     needs: [sign-deb-artifacts]

--- a/.github/workflows/staging-build-deb.yml
+++ b/.github/workflows/staging-build-deb.yml
@@ -390,7 +390,7 @@ jobs:
         run: |
           .github/scripts/setup_runners_service.sh deb --es
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
-          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin    
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin
   
   Test-ALERTING:
     needs: [sign-deb-artifacts]

--- a/.github/workflows/staging-build-docker.yml
+++ b/.github/workflows/staging-build-docker.yml
@@ -288,7 +288,7 @@ jobs:
         run: |
           .github/scripts/setup_runners_service.sh docker --es-nosec
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
-          ./gradlew :integTestRunner --tests "com.amazon.opendistroforelasticsearch.ad.rest.*IT" --tests "com.amazon.opendistroforelasticsearch.ad.e2e.*IT" -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest"
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest"
 
   Test-SQL:
     needs: [build-es-docker]
@@ -348,8 +348,8 @@ jobs:
         run: |
           .github/scripts/setup_runners_service.sh docker --es
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
-          ./gradlew :integTestRunner --tests "com.amazon.opendistroforelasticsearch.ad.rest.*IT" --tests "com.amazon.opendistroforelasticsearch.ad.e2e.*IT" -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin 
-          
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin  
+                    
   Test-ALERTING:
     needs: [build-es-docker]
     runs-on: [ubuntu-18.04]

--- a/.github/workflows/staging-build-docker.yml
+++ b/.github/workflows/staging-build-docker.yml
@@ -348,8 +348,8 @@ jobs:
         run: |
           .github/scripts/setup_runners_service.sh docker --es
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
-          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin  
-                    
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin
+        
   Test-ALERTING:
     needs: [build-es-docker]
     runs-on: [ubuntu-18.04]

--- a/.github/workflows/staging-build-rpm.yml
+++ b/.github/workflows/staging-build-rpm.yml
@@ -333,8 +333,8 @@ jobs:
         run: |
           .github/scripts/setup_runners_service.sh rpm --es
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
-          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin  
-            
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin
+  
   Test-ALERTING:
     needs: [Provision-Runners]
     name: Test-ALERTING

--- a/.github/workflows/staging-build-rpm.yml
+++ b/.github/workflows/staging-build-rpm.yml
@@ -289,7 +289,7 @@ jobs:
         run: |
           .github/scripts/setup_runners_service.sh rpm --es-nosec
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
-          ./gradlew :integTestRunner --tests "com.amazon.opendistroforelasticsearch.ad.rest.*IT" --tests "com.amazon.opendistroforelasticsearch.ad.e2e.*IT" -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest"
 
   Test-SQL:
     needs: [Provision-Runners]
@@ -333,8 +333,8 @@ jobs:
         run: |
           .github/scripts/setup_runners_service.sh rpm --es
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
-          ./gradlew :integTestRunner --tests "com.amazon.opendistroforelasticsearch.ad.rest.*IT" --tests "com.amazon.opendistroforelasticsearch.ad.e2e.*IT" -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin
-  
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin  
+            
   Test-ALERTING:
     needs: [Provision-Runners]
     name: Test-ALERTING

--- a/.github/workflows/staging-build-tar.yml
+++ b/.github/workflows/staging-build-tar.yml
@@ -286,8 +286,8 @@ jobs:
         run: |
           .github/scripts/setup_runners_service.sh zip --es
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
-          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin  
-            
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin
+  
   Test-ALERTING:
     needs: [build-es-artifacts]
     runs-on: [ubuntu-18.04]

--- a/.github/workflows/staging-build-tar.yml
+++ b/.github/workflows/staging-build-tar.yml
@@ -220,8 +220,8 @@ jobs:
         run: |
           .github/scripts/setup_runners_service.sh zip --es-nosec
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
-          ./gradlew :integTestRunner --tests "com.amazon.opendistroforelasticsearch.ad.rest.*IT" --tests "com.amazon.opendistroforelasticsearch.ad.e2e.*IT" -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest
-          
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest"
+
   Test-SQL:
     needs: [build-es-artifacts]
     runs-on: ubuntu-18.04
@@ -286,8 +286,8 @@ jobs:
         run: |
           .github/scripts/setup_runners_service.sh zip --es
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
-          ./gradlew :integTestRunner --tests "com.amazon.opendistroforelasticsearch.ad.rest.*IT" --tests "com.amazon.opendistroforelasticsearch.ad.e2e.*IT" -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest -Dhttps=true -Duser=admin -Dpassword=admin
-  
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin  
+            
   Test-ALERTING:
     needs: [build-es-artifacts]
     runs-on: [ubuntu-18.04]

--- a/.github/workflows/staging-build-windows.yml
+++ b/.github/workflows/staging-build-windows.yml
@@ -268,7 +268,7 @@ jobs:
           echo "running tests"
           cd ..\anomaly-detection
           dir
-          .\gradlew.bat integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin  
+          .\gradlew.bat integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin
 
   Test-ALERTING:
     needs: [build-es-artifacts, build-kibana-artifacts]

--- a/.github/workflows/staging-build-windows.yml
+++ b/.github/workflows/staging-build-windows.yml
@@ -195,7 +195,7 @@ jobs:
           echo running tests
           cd ..\anomaly-detection
           dir
-          .\gradlew.bat :integTestRunner --tests "com.amazon.opendistroforelasticsearch.ad.rest.*IT" --tests "com.amazon.opendistroforelasticsearch.ad.e2e.*IT" -D tests.rest.cluster=localhost:9200 -D tests.cluster=localhost:9200 -D tests.clustername=es-integrationtest --stacktrace
+          .\gradlew.bat integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest"
 
   Test-SQL:
     needs: [build-es-artifacts, build-kibana-artifacts]
@@ -268,7 +268,7 @@ jobs:
           echo "running tests"
           cd ..\anomaly-detection
           dir
-          .\gradlew.bat :integTestRunner --tests "com.amazon.opendistroforelasticsearch.ad.rest.*IT" --tests "com.amazon.opendistroforelasticsearch.ad.e2e.*IT" -D tests.rest.cluster=localhost:9200 -D tests.cluster=localhost:9200 -D tests.clustername=es-integrationtest -D https=true -D user=admin -D password=admin --stacktrace
+          .\gradlew.bat integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin  
 
   Test-ALERTING:
     needs: [build-es-artifacts, build-kibana-artifacts]


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/opendistro-build/issues/476
P41846943 

*Description of changes:*
Update the AD Integration Test command for release workflows as per the above issue

*Test Results:*
No way to test it right now since we don't have ODFE 1.12.0 built yet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
