### PR TITLE
Fix kibana notebooks zip name

### DIFF
--- a/bin/plugins.json
+++ b/bin/plugins.json
@@ -151,7 +151,7 @@
   },
   "notebooks-kibana": {
     "git": "opendistro-for-elasticsearch/kibana-notebooks",
-    "zip": "opendistro-notebooks/opendistroNoteboooksKibana",
+    "zip": "opendistro-notebooks/opendistroNotebooksKibana",
     "deb": "none",
     "rpm": "none",
     "windows": "none",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Zip name error fixed in this PR for **opendistroNoteboooksKibana**

*Test Results:*
Not required

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
