### PR TITLE
Add a OR condition to skip chown commands on ./optimize folder if not exist

### DIFF
--- a/kibana/linux_distributions/scripts/post_install.sh
+++ b/kibana/linux_distributions/scripts/post_install.sh
@@ -51,6 +51,6 @@ case $1 in
   ;;
 esac
 
-chown -R <%= user %>:<%= group %> <%= optimizeDir %>
+chown -R <%= user %>:<%= group %> <%= optimizeDir %> || echo no optimize folder
 chown <%= user %>:<%= group %> <%= dataDir %>
 chown <%= user %>:<%= group %> <%= pluginsDir %>


### PR DESCRIPTION
*Issue #, if available:*
V286471153

*Description of changes:*
This PR is to add a OR condition to skip chown commands on ./optimize folder if not exist

*Test Results:*
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/399329811

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
