### PR TITLE
Remove virtualenv requirements for docker building process as we do not need unit testings

### DIFF
--- a/.github/workflows/staging-build-docker.yml
+++ b/.github/workflows/staging-build-docker.yml
@@ -8,9 +8,6 @@ on:
 
 jobs:
   build-es-docker:
-    strategy:
-      matrix:
-        java: [14]
     name: Build ES Docker
     runs-on: ubuntu-18.04
     steps:
@@ -23,10 +20,8 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
 
-    - name: Set Up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
-      with:
-        java-version: ${{ matrix.java }}
+    - name: Install Required Packages
+      run: pip3 install jinja2-cli
 
     - name: Starting ES Docker Build
       env:
@@ -37,7 +32,7 @@ jobs:
         ODFE_VER=`./bin/version-info --od`
         echo "ODFE VERSION $ODFE_VER"
         workdir=`pwd`
-        sudo apt-get install python-virtualenv
+        #sudo apt-get install python-virtualenv
         ./download_plugins.sh
         cd elasticsearch
         security=`ls docker/build/elasticsearch/plugins/|grep opendistro_security|wc -l`
@@ -98,13 +93,15 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
+      - name: Install Required Packages
+        run: pip3 install jinja2-cli
 
       - name: Build Kibana Docker
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
         run: |
-          sudo apt-get install python-virtualenv
+          #sudo apt-get install python-virtualenv
           ODFE_VER=`./bin/version-info --od`
           echo "ODFE VERSION $ODFE_VER"
           ./download_kibana_plugins.sh
@@ -601,3 +598,4 @@ jobs:
         with:
           working-directory: kibana/plugins/anomaly-detection-kibana-plugin
           command: yarn cy:run-with-security --config baseurl=http://localhost:5601
+

--- a/elasticsearch/docker/Makefile
+++ b/elasticsearch/docker/Makefile
@@ -114,8 +114,8 @@ run-single: docker-compose
 run-cluster: docker-compose
 	DATA_VOLUME1=esdata1 DATA_VOLUME2=esdata2 $(DOCKER_COMPOSE) -f docker-compose.cluster.yml up elasticsearch1 elasticsearch2
 
-build: clean venv dockerfile docker-compose
-	-pyfiglet -f puffy -w 160 "Building ES "; \
+#build: clean venv dockerfile docker-compose
+build: clean dockerfile
 	docker build -t $(IMAGE_TAG):$(OPENDISTRO_VERSION) -f build/elasticsearch/Dockerfile build/elasticsearch || \
 	docker tag $(IMAGE_TAG):$(OPENDISTRO_VERSION) $(IMAGE_TAG):$(OPENDISTRO_VERSION)
 
@@ -143,7 +143,8 @@ venv: requirements.txt
 	touch venv;\
 
 # Generate the Dockerfiles from a Jinja2 template.
-dockerfile: venv templates/Dockerfile.j2
+#dockerfile: venv templates/Dockerfile.j2
+dockerfile:
 	jinja2 \
 		-D elastic_version='$(ELASTIC_VERSION)' \
 		-D plugin_url_paths='${PLUGIN_URL_PATHS}' \
@@ -164,3 +165,4 @@ docker-compose: venv templates/docker-compose.yml.j2 templates/docker-compose-fr
 	  templates/docker-compose.yml.j2 > docker-compose.yml; \
 	jinja2 \
 	  templates/docker-compose-fragment.yml.j2 > tests/docker-compose.yml; 
+

--- a/elasticsearch/docker/Makefile
+++ b/elasticsearch/docker/Makefile
@@ -116,7 +116,7 @@ run-cluster: docker-compose
 
 #build: clean venv dockerfile docker-compose
 build: clean dockerfile
-        #-pyfiglet -f puffy -w 160 "Building ES ";
+	#-pyfiglet -f puffy -w 160 "Building ES ";
 	docker build -t $(IMAGE_TAG):$(OPENDISTRO_VERSION) -f build/elasticsearch/Dockerfile build/elasticsearch || \
 	docker tag $(IMAGE_TAG):$(OPENDISTRO_VERSION) $(IMAGE_TAG):$(OPENDISTRO_VERSION)
 

--- a/elasticsearch/docker/Makefile
+++ b/elasticsearch/docker/Makefile
@@ -116,6 +116,7 @@ run-cluster: docker-compose
 
 #build: clean venv dockerfile docker-compose
 build: clean dockerfile
+        #-pyfiglet -f puffy -w 160 "Building ES ";
 	docker build -t $(IMAGE_TAG):$(OPENDISTRO_VERSION) -f build/elasticsearch/Dockerfile build/elasticsearch || \
 	docker tag $(IMAGE_TAG):$(OPENDISTRO_VERSION) $(IMAGE_TAG):$(OPENDISTRO_VERSION)
 

--- a/kibana/docker/Makefile
+++ b/kibana/docker/Makefile
@@ -54,7 +54,7 @@ lint: venv
 
 build: dockerfile
 	docker pull centos:7
-	 $(FIGLET) "build: $(BUILD_TYPE)"; \
+	# $(FIGLET) "build: $(BUILD_TYPE)";
 	docker build -t $(IMAGE_TAG):$(OPENDISTRO_VERSION) \
 	  -f build/kibana/Dockerfile build/kibana; \
     docker tag $(IMAGE_TAG):$(OPENDISTRO_VERSION) $(IMAGE_TAG):$(OPENDISTRO_VERSION);
@@ -83,7 +83,8 @@ venv: requirements.txt
 	touch venv
 
 # Generate the Dockerfiles from Jinja2 templates.
-dockerfile: venv templates/Dockerfile.j2
+#dockerfile: venv templates/Dockerfile.j2
+dockerfile:
 	jinja2 \
 	  -D artifacts_url='$(ARTIFACTS_URL)' \
 	  -D version_tag='${OPENDISTRO_VERSION}' \


### PR DESCRIPTION
*Issue #, if available:*
v286570428

*Description of changes:*
This PR is to remove virtualenv requirements for docker building process as we do not need unit testings

*Test Results:*
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/399499652

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
