### PR TITLE
Activate cronjob schedule for all staging workflows

### DIFF
--- a/.github/workflows/staging-build-deb.yml
+++ b/.github/workflows/staging-build-deb.yml
@@ -1,8 +1,8 @@
 name: Process Debian Artifacts
 
 on:
-#  schedule:
-#    - cron: '0 10 * * *'
+  schedule:
+    - cron: '0 10 * * *'
   repository_dispatch:
     types: [staging-build-deb]
 

--- a/.github/workflows/staging-build-docker.yml
+++ b/.github/workflows/staging-build-docker.yml
@@ -1,8 +1,8 @@
 name: Build ES Docker
 
 on:
-#  schedule:
-#    - cron: '30 10 * * *'
+  schedule:
+    - cron: '30 10 * * *'
   repository_dispatch:
     types: [staging-build-docker]
 

--- a/.github/workflows/staging-build-rpm.yml
+++ b/.github/workflows/staging-build-rpm.yml
@@ -1,8 +1,8 @@
 name: Process RPM Artifacts
 
 on:
-#  schedule:
-#    - cron: '0 10 * * *'
+  schedule:
+    - cron: '0 10 * * *'
   repository_dispatch:
     types: [staging-build-rpm]
 

--- a/.github/workflows/staging-build-tar.yml
+++ b/.github/workflows/staging-build-tar.yml
@@ -1,8 +1,8 @@
 name: Process TAR Artifacts
 
 on:
-#  schedule:
-#    - cron: '0 10 * * *'
+  schedule:
+    - cron: '0 10 * * *'
   repository_dispatch:
     types: [staging-build-tar]
 

--- a/.github/workflows/staging-build-windows.yml
+++ b/.github/workflows/staging-build-windows.yml
@@ -1,8 +1,8 @@
 name: Build Windows Exe using tar artifacts
 
 on:
-#  schedule:
-#    - cron: '30 10 * * *'
+  schedule:
+    - cron: '30 10 * * *'
   repository_dispatch:
     types: [staging-build-windows]
 

--- a/.github/workflows/test-cluster-static-domain-set-up.yml
+++ b/.github/workflows/test-cluster-static-domain-set-up.yml
@@ -7,8 +7,8 @@ name: Create testing cluster with static domain
 # NOTE: This workflow is based on the static ELBs pre-configured in the AWS account
 
 on:
-#  schedule:
-#    - cron: '0 11 * * *'
+  schedule:
+    - cron: '0 11 * * *'
   repository_dispatch:
     types: [test-cluster-static-domain-set-up]
 


### PR DESCRIPTION
*Issue #, if available:*
P42248533

*Description of changes:*
Activate cronjob schedule for all staging workflows so that recent artifacts are picked up and build daily until testing phase.

*Test Results:*
Not required

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
