### PR TITLE
Disable showInsecureClusterWarning for Kibana 7.10 configurations

### DIFF
--- a/kibana/docker/build/kibana/config/kibana.yml
+++ b/kibana/docker/build/kibana/config/kibana.yml
@@ -33,3 +33,4 @@ opendistro_security.cookie.secure: false
 newsfeed.enabled: false
 telemetry.optIn: false
 telemetry.enabled: false
+security.showInsecureClusterWarning: false

--- a/kibana/linux_distributions/config/kibana.yml
+++ b/kibana/linux_distributions/config/kibana.yml
@@ -30,3 +30,4 @@ opendistro_security.cookie.secure: false
 newsfeed.enabled: false
 telemetry.optIn: false
 telemetry.enabled: false
+security.showInsecureClusterWarning: false


### PR DESCRIPTION
*Issue #, if available:*
V291643202

*Description of changes:*
This PR is to disable showInsecureClusterWarning for Kibana 7.10 configurations

*Test Results:*
Test with local env and clusters

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
