### PR TITLE
Change SG for AMI to the default SG to default VPC

### DIFF
--- a/.github/workflows/staging-build-ami.yml
+++ b/.github/workflows/staging-build-ami.yml
@@ -3,6 +3,8 @@ name: Build ODFE AMI
 on:
   repository_dispatch:
     types: [staging-build-ami]
+  push:
+    branches: [ami-sg-V290419891]
     
 jobs:
   build:
@@ -28,7 +30,7 @@ jobs:
         OD_version=`./bin/version-info --od`
         export region_name="us-east-1"
         export os="amazonLinux"
-        export security_group_id="sg-0a4180f6848aa8675"
+        export security_group_id="sg-cb2f6f88"
     
         
         # please check this during the new release, are we getting the latest ami id

--- a/.github/workflows/staging-build-ami.yml
+++ b/.github/workflows/staging-build-ami.yml
@@ -28,7 +28,7 @@ jobs:
         OD_version=`./bin/version-info --od`
         export region_name="us-east-1"
         export os="amazonLinux"
-        export security_group_id="sg-0ffdd3b008cfb0b63"
+        export security_group_id="sg-0a4180f6848aa8675"
     
         
         # please check this during the new release, are we getting the latest ami id

--- a/.github/workflows/staging-build-ami.yml
+++ b/.github/workflows/staging-build-ami.yml
@@ -3,8 +3,6 @@ name: Build ODFE AMI
 on:
   repository_dispatch:
     types: [staging-build-ami]
-  push:
-    branches: [ami-sg-V290419891]
     
 jobs:
   build:


### PR DESCRIPTION
*Issue #, if available:*
v290419891

*Description of changes:*
This PR is to change SG for AMI to the default SG to default VPC

*Test Results:*
https://github.com/opendistro-for-elasticsearch/opendistro-build/runs/1554062177?check_suite_focus=true
The instance is created without issues now so I cancel the run

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
