### PR TITLE
Add selectors to K8s services

### DIFF
--- a/helm/opendistro-es/templates/elasticsearch/es-data-svc.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-svc.yaml
@@ -33,6 +33,7 @@ spec:
     name: rca
   clusterIP: None
   selector:
+{{ include "opendistro-es.labels.selector" . | indent 4 }}
   {{- if .Values.elasticsearch.data.dedicatedPod.enabled }}
     role: data
   {{- else }}

--- a/helm/opendistro-es/templates/elasticsearch/es-service.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-service.yaml
@@ -34,6 +34,7 @@ spec:
     - name: rca
       port: 9650
   selector:
+{{ include "opendistro-es.labels.selector" . | indent 4 }}
   {{- if .Values.elasticsearch.client.dedicatedPod.enabled }}
     role: client
   {{- else }}

--- a/helm/opendistro-es/templates/elasticsearch/master-svc.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/master-svc.yaml
@@ -28,5 +28,6 @@ spec:
       protocol: TCP
   clusterIP: None
   selector:
+{{ include "opendistro-es.labels.selector" . | indent 4 }}
     role: master
 {{- end }}

--- a/helm/opendistro-es/templates/kibana/kibana-service.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-service.yaml
@@ -29,6 +29,7 @@ spec:
     port: {{ .Values.kibana.externalPort }}
     targetPort: {{ .Values.kibana.port }}
   selector:
+{{ include "opendistro-es.labels.selector" . | indent 4 }}
     role: kibana
   type: {{ .Values.kibana.service.type }}
 {{- end }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add selectors to K8s services. This solves a bug where OpenDistro and Redis are installed in the same namespace (Redis uses role=master too).

*Test Results:*

Redis & OpenDistro working together in the same namespace 👍 

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
