### PR TITLE
[Helm] Allow customizing port name in kibana service

### DIFF
--- a/helm/opendistro-es/templates/kibana/kibana-service.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-service.yaml
@@ -25,7 +25,7 @@ metadata:
   name: {{ template "opendistro-es.fullname" . }}-kibana-svc
 spec:
   ports:
-  - name: kibana-svc
+  - name: {{ .Values.kibana.service.portName }}
     port: {{ .Values.kibana.externalPort }}
     targetPort: {{ .Values.kibana.port }}
   selector:

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -94,6 +94,7 @@ kibana:
 
   service:
     type: ClusterIP
+    portName: kibana-svc
     annotations: {}
 
   config: {}


### PR DESCRIPTION
*Issue #, if available:*

When exposing kibana service via Istio the port name should start with `http-`. Need the ability to override the default port name via chart values.

*Description of changes:*

Allow customizing the name of the service port via chart values by setting `kibana.service.portName`. The default name `kibana-svc` is kept.

*Test Results:*

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
