### PR TITLE
Change Daily WhiteSource scan workflow to provide ami id and change standalone WhiteSource to show project url

### DIFF
--- a/.github/workflows/check-vulnerability-standalone.yml
+++ b/.github/workflows/check-vulnerability-standalone.yml
@@ -5,10 +5,8 @@ name: Standalone Vulnerability Scan
 # Example: client_payload: { "branch": "master", "repo": "index-management" }
 
 on:
-#  repository_dispatch:
-#    types: [check-vulnerability-standalone]
-  push:
-    branches: [sreekarj_whitesource]
+  repository_dispatch:
+    types: [check-vulnerability-standalone]
 
 jobs:
   whitesource-vulnerability-scan:
@@ -32,16 +30,15 @@ jobs:
           export PATH=$JAVA_HOME:$PATH
           cd standalone-tools ; ls -ltr 
           gradle -v; mvn -v ; npm -v; yarn -v
-          #branch=${{github.event.client_payload.branch}}
-          #repo=${{github.event.client_payload.repo}}
-          branch=master
-          repo=opendistro-build
+          branch=${{github.event.client_payload.branch}}
+          repo=${{github.event.client_payload.repo}}
           git clone --branch $branch --single-branch https://github.com/opendistro-for-elasticsearch/$repo.git
           wget -q https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar
           ls -ltr
-          echo "project_url=$(java -jar wss-unified-agent.jar -c wss-unified-agent.config -d $repo -apiKey $wss_apikey -product ODFE -project $repo | grep "Project name" | sed 's/^.\{,41\}//')" >> $GITHUB_ENV
-          echo ${{env.project_url}}
-          #cat whitesource/*/*
+          echo 'project_url<<EOF' >> $GITHUB_ENV
+          java -jar wss-unified-agent.jar -c wss-unified-agent.config -d $repo -apiKey $wss_apikey -product ODFE -project $repo | grep "Project name" | sed 's/^.\{,41\}//' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+          cat whitesource/*/*
       - name: WhiteSource URL
-        run: echo ${{env.project_url}}
+        run: echo "${{env.project_url}}"
 

--- a/.github/workflows/check-vulnerability-standalone.yml
+++ b/.github/workflows/check-vulnerability-standalone.yml
@@ -41,7 +41,7 @@ jobs:
           ls -ltr
           echo "project_url=$(java -jar wss-unified-agent.jar -c wss-unified-agent.config -d $repo -apiKey $wss_apikey -product ODFE -project $repo | grep "Project name" | sed 's/^.\{,41\}//')" >> $GITHUB_ENV
           echo ${{env.project_url}}
-          cat whitesource/*/*
+          #cat whitesource/*/*
       - name: WhiteSource URL
         run: echo ${{env.project_url}}
 

--- a/.github/workflows/check-vulnerability-standalone.yml
+++ b/.github/workflows/check-vulnerability-standalone.yml
@@ -5,9 +5,10 @@ name: Standalone Vulnerability Scan
 # Example: client_payload: { "branch": "master", "repo": "index-management" }
 
 on:
-  repository_dispatch:
-    types: [check-vulnerability-standalone]
-
+#  repository_dispatch:
+#    types: [check-vulnerability-standalone]
+  push:
+    branches: [sreekarj_whitesource]
 
 jobs:
   whitesource-vulnerability-scan:
@@ -31,12 +32,15 @@ jobs:
           export PATH=$JAVA_HOME:$PATH
           cd standalone-tools ; ls -ltr 
           gradle -v; mvn -v ; npm -v; yarn -v
-          branch=${{github.event.client_payload.branch}}
-          repo=${{github.event.client_payload.repo}}
+          #branch=${{github.event.client_payload.branch}}
+          #repo=${{github.event.client_payload.repo}}
+          branch=master
+          repo=opendistro-build
           git clone --branch $branch --single-branch https://github.com/opendistro-for-elasticsearch/$repo.git
           wget -q https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar
           ls -ltr
           echo "project_url=$(java -jar wss-unified-agent.jar -c wss-unified-agent.config -d $repo -apiKey $wss_apikey -product ODFE -project $repo | grep "Project name" | sed 's/^.\{,41\}//')" >> $GITHUB_ENV
+          echo ${{env.project_url}}
           cat whitesource/*/*
       - name: WhiteSource URL
         run: echo ${{env.project_url}}

--- a/.github/workflows/check-vulnerability-whitesource.yml
+++ b/.github/workflows/check-vulnerability-whitesource.yml
@@ -1,13 +1,10 @@
 name: WhiteSource Vulnerability Scan
 
 on:
-#  schedule:
-#    - cron: '30 10 * * *'
-#  repository_dispatch:
-#    types: [check-vulnerability-whitesource]
-
-  push:
-    branches: [sreekarj_whitesource]     
+  schedule:
+    - cron: '30 10 * * *'
+  repository_dispatch:
+    types: [check-vulnerability-whitesource]
 
 jobs:
   Provision-Runners:
@@ -79,8 +76,7 @@ jobs:
           password: ${{secrets.MAIL_PASSWORD}}
           subject: ODFE Vulnerability and License Scan - Daily Run
           body: ${{needs.whitesource-vulnerability-scan.outputs.mail_content_output}}
-          #to: odfe-infra-team@amazon.com,mmakaria@amazon.com
-          to: sreekarj@amazon.com
+          to: odfe-infra-team@amazon.com,mmakaria@amazon.com
           from: Opendistro Elasticsearch
           content_type: text/html
 

--- a/.github/workflows/check-vulnerability-whitesource.yml
+++ b/.github/workflows/check-vulnerability-whitesource.yml
@@ -96,5 +96,4 @@ jobs:
       - name: AWS Cli Processing
         run: |
           RUNNERS="odfe-wss-scan"
-          release-tools/scripts/setup_runners.sh terminate $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }} ami-086e8a98280780e63
-
+          release-tools/scripts/setup_runners.sh terminate $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }}

--- a/.github/workflows/check-vulnerability-whitesource.yml
+++ b/.github/workflows/check-vulnerability-whitesource.yml
@@ -1,10 +1,13 @@
 name: WhiteSource Vulnerability Scan
 
 on:
-  schedule:
-    - cron: '30 10 * * *'
-  repository_dispatch:
-    types: [check-vulnerability-whitesource]
+#  schedule:
+#    - cron: '30 10 * * *'
+#  repository_dispatch:
+#    types: [check-vulnerability-whitesource]
+
+  push:
+    branches: [sreekarj_whitesource]     
 
 jobs:
   Provision-Runners:
@@ -21,7 +24,7 @@ jobs:
       - name: AWS Cli Processing
         run: |
           RUNNERS="odfe-wss-scan"
-          release-tools/scripts/setup_runners.sh run $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }}
+          release-tools/scripts/setup_runners.sh run $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }} ami-086e8a98280780e63
 
   whitesource-vulnerability-scan:
     needs: [Provision-Runners]
@@ -76,7 +79,8 @@ jobs:
           password: ${{secrets.MAIL_PASSWORD}}
           subject: ODFE Vulnerability and License Scan - Daily Run
           body: ${{needs.whitesource-vulnerability-scan.outputs.mail_content_output}}
-          to: odfe-infra-team@amazon.com,mmakaria@amazon.com
+          #to: odfe-infra-team@amazon.com,mmakaria@amazon.com
+          to: sreekarj@amazon.com
           from: Opendistro Elasticsearch
           content_type: text/html
 
@@ -96,5 +100,5 @@ jobs:
       - name: AWS Cli Processing
         run: |
           RUNNERS="odfe-wss-scan"
-          release-tools/scripts/setup_runners.sh terminate $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }}
+          release-tools/scripts/setup_runners.sh terminate $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }} ami-086e8a98280780e63
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change Daily WhiteSource scan workflow to provide ami id to the setup runners as per the new script, and change standalone WhiteSource to show project url

*Test Results:*
Standalone : https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/470126253
Daily scan : https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/470070352

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
