### PR TITLE
Change the storing artifact script to pick the artifact with the highest build number

### DIFF
--- a/.github/workflows/staging-copy-artifacts.yml
+++ b/.github/workflows/staging-copy-artifacts.yml
@@ -3,10 +3,8 @@ name: Staging Copy Artifacts
 on:
 #  schedule:
 #    - cron: '30 10 * * *' 
-#  repository_dispatch:
-#    types: [staging-copy-artifacts]
-  push:
-    branches: [sreekarj_V303549183]
+  repository_dispatch:
+    types: [staging-copy-artifacts]
 
 jobs:
   Staging-Copy-Artifacts:

--- a/.github/workflows/staging-copy-artifacts.yml
+++ b/.github/workflows/staging-copy-artifacts.yml
@@ -3,8 +3,10 @@ name: Staging Copy Artifacts
 on:
 #  schedule:
 #    - cron: '30 10 * * *' 
-  repository_dispatch:
-    types: [staging-copy-artifacts]
+#  repository_dispatch:
+#    types: [staging-copy-artifacts]
+  push:
+    branches: [sreekarj_V303549183]
 
 jobs:
   Staging-Copy-Artifacts:

--- a/release-tools/scripts/staging-copy-artifacts.py
+++ b/release-tools/scripts/staging-copy-artifacts.py
@@ -20,6 +20,7 @@ import sys
 import yaml
 import hashlib
 import requests
+import re
 
 s3 = boto3.client('s3')
 
@@ -104,7 +105,8 @@ def get_latest_plugin(plugin_name,plugin_version,plugin_build,bucket_name,folder
         print("plugin_type " + plugin_type)
         suffix = plugin_type
         key = ""
-        plugin_list = []
+        temp = 0
+        plg = ""
         for artifact in sorted(response['Contents'], key=lambda x: x['LastModified'], reverse=True):
             key = artifact['Key']
             if plugin_build is None:
@@ -118,11 +120,17 @@ def get_latest_plugin(plugin_name,plugin_version,plugin_build,bucket_name,folder
                 arch = ""
             if plugin_name in key and plugin_version in key and build_number in key and platform in key and arch in key:
                 if key.endswith(plugin_type):
-                    plugin_list.append(key)
                     print(key)
-        plugin_list.sort()
-        print("The artifact selected " + str(plugin_list[-1]))
-        return str(plugin_list[-1])
+                    tmp=key.split('-build-')[1]
+                    bld_no=re.split("[-_.]",tmp)[0]
+                    print("build number")
+                    print(bld_no)
+                    if bld_no.isdigit():
+                        if float(bld_no) > float(temp):
+                            plg = key
+                            temp = bld_no
+        print("Plugin selected " + plg)
+        return plg
     except:
         raise
 

--- a/release-tools/scripts/staging-copy-artifacts.py
+++ b/release-tools/scripts/staging-copy-artifacts.py
@@ -121,8 +121,8 @@ def get_latest_plugin(plugin_name,plugin_version,plugin_build,bucket_name,folder
                     plugin_list.append(key)
                     print(key)
         plugin_list.sort()
-        print("The artifact selected " + str(plugin_list[0]))
-        return key
+        print("The artifact selected " + str(plugin_list[-1]))
+        return str(plugin_list[-1])
     except:
         raise
 

--- a/release-tools/scripts/staging-copy-artifacts.py
+++ b/release-tools/scripts/staging-copy-artifacts.py
@@ -104,6 +104,7 @@ def get_latest_plugin(plugin_name,plugin_version,plugin_build,bucket_name,folder
         print("plugin_type " + plugin_type)
         suffix = plugin_type
         key = ""
+        plugin_list = []
         for artifact in sorted(response['Contents'], key=lambda x: x['LastModified'], reverse=True):
             key = artifact['Key']
             if plugin_build is None:
@@ -117,8 +118,10 @@ def get_latest_plugin(plugin_name,plugin_version,plugin_build,bucket_name,folder
                 arch = ""
             if plugin_name in key and plugin_version in key and build_number in key and platform in key and arch in key:
                 if key.endswith(plugin_type):
+                    plugin_list.append(key)
                     print(key)
-                    break
+        plugin_list.sort()
+        print("The artifact selected " + str(plugin_list[0]))
         return key
     except:
         raise


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Change the storing artifact script to pick the artifact with the highest build number instead of the last modified. 

*Test Results:*
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/481459695

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
