### PR TITLE
remove license info from the windows build script and move it to git secrets

### DIFF
--- a/.github/workflows/staging-build-windows.yml
+++ b/.github/workflows/staging-build-windows.yml
@@ -26,6 +26,8 @@ jobs:
         java-version: 14
 
     - name: Build Windows
+      env:
+        install4j_license: ${{ secrets.INSTALL4J_LICENSE }}
       run: ./elasticsearch/windows/opendistro-windows-build.sh
         
   build-kibana-artifacts:

--- a/.github/workflows/staging-build-windows.yml
+++ b/.github/workflows/staging-build-windows.yml
@@ -48,6 +48,8 @@ jobs:
         java-version: 14
 
     - name: Build Kibana
+      env:
+        install4j_license: ${{ secrets.INSTALL4J_LICENSE }}
       run: ./kibana/windows/opendistro-windows-kibana-build.sh
 
   Test-ISM-NoSec:

--- a/elasticsearch/windows/opendistro-windows-build.sh
+++ b/elasticsearch/windows/opendistro-windows-build.sh
@@ -68,7 +68,7 @@ aws s3 cp s3://odfe-windows/ODFE.install4j .
 echo $?
 
 # Build the exe
-install4j8.0.4/bin/install4jc -d $TARGET_DIR -D sourcedir=./$PACKAGE_NAME-$OD_VERSION,version=$OD_VERSION --license="L-M8-AMAZON_DEVELOPMENT_CENTER_INDIA_PVT_LTD#50047687020001-3rhvir3mkx479#484b6" ./ODFE.install4j
+install4j8.0.4/bin/install4jc -d $TARGET_DIR -D sourcedir=./$PACKAGE_NAME-$OD_VERSION,version=$OD_VERSION --license=$install4j_license ./ODFE.install4j
 
 # List installed plugins
 ls -ltr $TARGET_DIR

--- a/kibana/windows/opendistro-windows-kibana-build.sh
+++ b/kibana/windows/opendistro-windows-kibana-build.sh
@@ -74,7 +74,7 @@ rm -rf install4j_unix_8_0_4.tar.gz
 aws s3 cp s3://odfe-windows/ODFE-Kibana.install4j . --quiet ; echo $0
 
  #Build the exe
-install4j8.0.4/bin/install4jc -d $TARGET_DIR -D sourcedir=./$PACKAGE_NAME,version=$OD_VERSION --license="L-M8-AMAZON_DEVELOPMENT_CENTER_INDIA_PVT_LTD#50047687020001-3rhvir3mkx479#484b6" ./ODFE-Kibana.install4j
+install4j8.0.4/bin/install4jc -d $TARGET_DIR -D sourcedir=./$PACKAGE_NAME,version=$OD_VERSION --license=$install4j_license ./ODFE-Kibana.install4j
 ls -ltr $TARGET_DIR
 
 # Copy to s3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
remove install4j license info from the windows staging build script and move it to git secrets

*Test Results:*
Test will not pass due to the new ODFE structure

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
