### PR TITLE
Include Ingress annotations for HTTPS backend

### DIFF
--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -398,6 +398,9 @@ elasticsearch:
       annotations: {}
       #  kubernetes.io/ingress.class: nginx
       #  kubernetes.io/tls-acme: "true"
+      #  # Depending on your Ingress Controller you may need to set one of the two below annotations to have NGINX call the backend using HTTPS
+      #  nginx.org/ssl-services:"{{ template "opendistro-es.fullname" . }}-client-service"
+      #  nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
       labels: {}
       path: /
       hosts:


### PR DESCRIPTION
Out of the box calls to the Elastic client ingress can fail with the following error: `received plaintext http traffic on an https channel, closing connection`

See for example: https://discuss.elastic.co/t/elasticsearch-with-ingress-received-plaintext-http-traffic-on-an-https-channel/246549

To prevent this, an annotation is necessary that depends on the Ingress Controller used (nginx-ingress or ingress-nginx)

*Issue #, if available:*

*Description of changes:*

*Test Results:*

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
