### PR TITLE
Add new data prepper staging location and comment out debs sync back to prod bucket

### DIFF
--- a/elasticsearch/linux_distributions/deb-signing.sh
+++ b/elasticsearch/linux_distributions/deb-signing.sh
@@ -157,7 +157,7 @@ echo HOME $HOME
 ls -l ~/.aptly/public/pool/
 ls -l ~/.aptly/public/pool/*/*
 
-echo "Sync rpms back to the repo"
+echo "Sync debs back to the repo"
 #aws s3 sync $REPO_DOWNLOADSDIR/debs ${S3_PROD_BASEURL}downloads/debs  --quiet; echo $?
 aws s3 sync ~/.aptly/public/ ${S3_PROD_BASEURL}staging/apt/ --quiet; echo $?
 aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/debs/*"

--- a/elasticsearch/linux_distributions/deb-signing.sh
+++ b/elasticsearch/linux_distributions/deb-signing.sh
@@ -158,7 +158,7 @@ ls -l ~/.aptly/public/pool/
 ls -l ~/.aptly/public/pool/*/*
 
 echo "Sync rpms back to the repo"
-aws s3 sync $REPO_DOWNLOADSDIR/debs ${S3_PROD_BASEURL}downloads/debs  --quiet; echo $?
+#aws s3 sync $REPO_DOWNLOADSDIR/debs ${S3_PROD_BASEURL}downloads/debs  --quiet; echo $?
 aws s3 sync ~/.aptly/public/ ${S3_PROD_BASEURL}staging/apt/ --quiet; echo $?
 aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/debs/*"
 aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/staging/apt/*"

--- a/release-tools/scripts/manifest.yml
+++ b/release-tools/scripts/manifest.yml
@@ -319,10 +319,10 @@ plugins:
   -
     plugin_basename: opendistro-data-prepper
     plugin_git: opendistro-for-elasticsearch/Data-Prepper
-    plugin_version: 0.7.0
+    plugin_version: 0.7.1
     plugin_build:
     plugin_spec: [linux_x64_tar.gz,linux_x64_zip,macos_x64_tar.gz,macos_x64_zip]
     plugin_category: elasticsearch-clients
     release_candidate: false
-    plugin_location_staging: [default: "s3://artifacts.dataprepper.amazon.com/"]
+    plugin_location_staging: [default: "s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/elasticsearch-clients/data-prepper/"]
     plugin_location_prod: [default: "s3://artifacts.opendistroforelasticsearch.amazon.com/tarball/opendistroforelasticsearch-data-prepper/"]


### PR DESCRIPTION
*Issue #, if available:*
V313270097

*Description of changes:*
This PR is to add new data prepper staging location and comment out debs sync back to prod bucket.

*Test Results:*
No Need.

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
