### PR TITLE
Make DataPrepper work with new env

### DIFF
--- a/.github/workflows/prod-sync-data-prepper.yml
+++ b/.github/workflows/prod-sync-data-prepper.yml
@@ -21,13 +21,14 @@ jobs:
     - name: S3 sync artifacts
       run: |
         #!/bin/bash
-        S3_BUCKET_PROD="artifacts.opendistroforelasticsearch.amazon.com"
-        TARGET_DIR=`./bin/plugins-info data-prepper zip --require-install-false`
-        TAG_VERSION="v$(./bin/plugins-info data-prepper cutversion --require-install-false | tr ' ' '\n' | uniq | sort -V | head -n 1)"
+        S3_URL_DATAPREPPER="s3://artifacts.dataprepper.amazon.com/"
+        S3_URL_DATAPREPPER_STAGING=`release-tools/scripts/plugin_parser.sh opendistroforelasticsearch-data-prepper plugin_location_staging | sed 's/[][}{"]*//g' | awk -F ':' '{print $2 ":" $3}'`
+        S3_URL_DATAPREPPER_PROD=`release-tools/scripts/plugin_parser.sh opendistroforelasticsearch-data-prepper plugin_location_prod | sed 's/[][}{"]*//g' | awk -F ':' '{print $2 ":" $3}'`
+        TAG_VERSION=`release-tools/scripts/plugin_parser.sh opendistroforelasticsearch-data-prepper plugin_version`
 
         echo $TAG_VERSION
-        aws s3 sync s3://$S3_BUCKET_PROD/$TARGET_DIR/ s3://$S3_BUCKET_PROD/tarball/opendistroforelasticsearch-data-prepper/ --exclude "*" --include "data-prepper-jdk-${TAG_VERSION}*" --quiet
-        aws s3 sync s3://$S3_BUCKET_PROD/$TARGET_DIR/ s3://$S3_BUCKET_PROD/tarball/opendistroforelasticsearch-data-prepper/ --exclude "*" --include "data-prepper-${TAG_VERSION}*" --quiet
+        aws s3 sync $S3_URL_DATAPREPPER_STAGING $S3_URL_DATAPREPPER_PROD --exclude "*" --include "opendistroforelasticsearch-data-prepper-jdk-${TAG_VERSION}*" --quiet
+        aws s3 sync $S3_URL_DATAPREPPER_STAGING $S3_URL_DATAPREPPER_PROD --exclude "*" --include "opendistroforelasticsearch-data-prepper-${TAG_VERSION}*" --quiet
         aws s3 ls s3://$S3_BUCKET_PROD/tarball/opendistroforelasticsearch-data-prepper/ | grep $TAG_VERSION
         aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/tarball/opendistroforelasticsearch-data-prepper/*"
 

--- a/.github/workflows/prod-sync-data-prepper.yml
+++ b/.github/workflows/prod-sync-data-prepper.yml
@@ -20,7 +20,6 @@ jobs:
 
     - name: S3 sync artifacts
       run: |
-        #!/bin/bash
         S3_URL_DATAPREPPER="s3://artifacts.dataprepper.amazon.com/"
         S3_URL_DATAPREPPER_STAGING=`release-tools/scripts/plugin_parser.sh opendistroforelasticsearch-data-prepper plugin_location_staging | sed 's/[][}{"]*//g' | awk -F ':' '{print $2 ":" $3}'`
         S3_URL_DATAPREPPER_PROD=`release-tools/scripts/plugin_parser.sh opendistroforelasticsearch-data-prepper plugin_location_prod | sed 's/[][}{"]*//g' | awk -F ':' '{print $2 ":" $3}'`

--- a/.github/workflows/staging-build-data-prepper.yml
+++ b/.github/workflows/staging-build-data-prepper.yml
@@ -16,23 +16,24 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
+
+    - name: required utilites
+      run: release-tools/scripts/required_packages.sh
 
     - name: S3 sync artifacts
       run: |
         #!/bin/bash
-        S3_BUCKET_PROD="artifacts.opendistroforelasticsearch.amazon.com"
-        S3_BUCKET_DATAPREPPER="artifacts.dataprepper.amazon.com"
-        TARGET_DIR=`./bin/plugins-info data-prepper zip --require-install-false`
-        TAG_VERSION="v$(./bin/plugins-info data-prepper cutversion --require-install-false | tr ' ' '\n' | uniq | sort -V | head -n 1)"
+        S3_URL_DATAPREPPER="s3://artifacts.dataprepper.amazon.com/"
+        S3_URL_DATAPREPPER_STAGING=`release-tools/scripts/plugin_parser.sh opendistroforelasticsearch-data-prepper plugin_location_staging | sed 's/[][}{"]*//g' | awk -F ':' '{print $2 ":" $3}'`
+        TAG_VERSION=`release-tools/scripts/plugin_parser.sh opendistroforelasticsearch-data-prepper plugin_version`
 
         echo $TAG_VERSION
-        aws s3 sync s3://$S3_BUCKET_DATAPREPPER/ s3://$S3_BUCKET_PROD/$TARGET_DIR/ --exclude "*" --include "data-prepper-jdk-${TAG_VERSION}*" --quiet
-        aws s3 sync s3://$S3_BUCKET_DATAPREPPER/ s3://$S3_BUCKET_PROD/$TARGET_DIR/ --exclude "*" --include "data-prepper-${TAG_VERSION}*" --quiet
-        aws s3 ls s3://$S3_BUCKET_PROD/$TARGET_DIR/ | grep $TAG_VERSION
-        aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/$TARGET_DIR/*"
+        aws s3 sync $S3_URL_DATAPREPPER $S3_URL_DATAPREPPER_STAGING --exclude "*" --include "opendistroforelasticsearch-data-prepper-jdk-${TAG_VERSION}*" --quiet
+        aws s3 sync $S3_URL_DATAPREPPER $S3_URL_DATAPREPPER_STAGING --exclude "*" --include "opendistroforelasticsearch-data-prepper-${TAG_VERSION}*" --quiet
+        aws s3 ls $S3_URL_DATAPREPPER_STAGING | grep $TAG_VERSION
 
   sync-dataprepper-docker-images:
     name: sync-dataprepper-docker-images
@@ -43,6 +44,9 @@ jobs:
         java: [14]
     steps:
     - uses: actions/checkout@v1
+
+    - name: required utilites
+      run: release-tools/scripts/required_packages.sh
 
     - name: Setup Java
       uses: actions/setup-java@v1
@@ -55,13 +59,15 @@ jobs:
           DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
       run: |
         #!/bin/bash
-        TAG_VERSION="v$(./bin/plugins-info data-prepper cutversion --require-install-false | tr ' ' '\n' | uniq | sort -V | head -n 1)"
+        TAG_VERSION=`release-tools/scripts/plugin_parser.sh opendistroforelasticsearch-data-prepper plugin_version`
         DOCKER_REG="opendistroforelasticsearch/data-prepper"
         echo $TAG_VERSION
-        git clone --depth 1 --branch $TAG_VERSION https://github.com/opendistro-for-elasticsearch/Data-Prepper.git
+        git clone --depth 1 --branch v$TAG_VERSION https://github.com/opendistro-for-elasticsearch/Data-Prepper.git
         cd Data-Prepper
         ./gradlew -Prelease :release:docker:docker
-        IMAGE_ID=`docker images | grep data-prepper/data-prepper | awk -F ' ' '{print $3}'`
+        docker images
+        IMAGE_ID=`docker images | grep data-prepper | awk -F ' ' '{print $3}'`
+        echo $IMAGE_ID
         docker login --username $DOCKER_USER --password $DOCKER_PASS
         docker tag $IMAGE_ID $DOCKER_REG:$TAG_VERSION
         docker tag $IMAGE_ID $DOCKER_REG:latest

--- a/.github/workflows/staging-build-data-prepper.yml
+++ b/.github/workflows/staging-build-data-prepper.yml
@@ -25,7 +25,6 @@ jobs:
 
     - name: S3 sync artifacts
       run: |
-        #!/bin/bash
         S3_URL_DATAPREPPER="s3://artifacts.dataprepper.amazon.com/"
         S3_URL_DATAPREPPER_STAGING=`release-tools/scripts/plugin_parser.sh opendistroforelasticsearch-data-prepper plugin_location_staging | sed 's/[][}{"]*//g' | awk -F ':' '{print $2 ":" $3}'`
         TAG_VERSION=`release-tools/scripts/plugin_parser.sh opendistroforelasticsearch-data-prepper plugin_version`

--- a/release-tools/scripts/manifest.yml
+++ b/release-tools/scripts/manifest.yml
@@ -317,9 +317,9 @@ plugins:
     plugin_location_staging: [default: "s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/elasticsearch-clients/perftop/"]
     plugin_location_prod: [default: "s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/perftop/"]
   -
-    plugin_basename: opendistro-data-prepper
+    plugin_basename: opendistroforelasticsearch-data-prepper
     plugin_git: opendistro-for-elasticsearch/Data-Prepper
-    plugin_version: 0.7.1
+    plugin_version: 0.7.1-alpha
     plugin_build:
     plugin_spec: [linux_x64_tar.gz,linux_x64_zip,macos_x64_tar.gz,macos_x64_zip]
     plugin_category: elasticsearch-clients


### PR DESCRIPTION
*Issue #, if available:*
V311401608

*Description of changes:*
This PR is to make DataPrepper work with new env

*Test Results:*
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/538405093

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
