### PR TITLE
Make RPM ARM64 with integTest running on new runner

### DIFF
--- a/.github/workflows/staging-test-rpm-arm64.yml
+++ b/.github/workflows/staging-test-rpm-arm64.yml
@@ -27,7 +27,7 @@ jobs:
           RUNNERS+="odfe-rpm-sql-arm64,odfe-rpm-ad-arm64,odfe-rpm-alerting-arm64,"
           RUNNERS+="odfe-rpm-ad-kibana-nosec-arm64,odfe-rpm-sql-kibana-nosec-arm64,"
           RUNNERS+="odfe-rpm-ad-kibana-arm64,odfe-rpm-sec-kibana-arm64,odfe-rpm-kibana-nb-nosec-arm64"
-          release-tools/scripts/setup_runners.sh run $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }} ami-0ed17173ab64255b1
+          release-tools/scripts/setup_runners.sh run $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }} ami-0824bd49967ce7fe4
 
   Test-ISM-NoSec:
     needs: [Provision-Runners]

--- a/release-tools/scripts/setup_runners.sh
+++ b/release-tools/scripts/setup_runners.sh
@@ -126,7 +126,7 @@ SETUP_GIT_TOKEN=$3
 # AMI on us-west-2
 # Distro      Arch  Recommand Username AMI-ID                Java  Comments
 # RPM-al2     x64   YES       ec2-user ami-086e8a98280780e63 none  need to install jdk by workflow
-# RPM-al2     arm64 YES       ec2-user on hold               jdk14 preinstall
+# RPM-al2     arm64 YES       ec2-user ami-0824bd49967ce7fe4 jdk14 preinstall with tar.gz
 # RPM-centos8 x64   NO        centos   ami-011f59f50bac33376 jdk15 preinstall
 # RPM-centos8 arm64 NO        centos   ami-0ed17173ab64255b1 jdk15 preinstall
 # DEB-ubu1804 arm64 YES       ubuntu   ami-055197d43e4ec7482 jdk14 preinstall disable daily updates


### PR DESCRIPTION
*Issue #, if available:*
V313743037

*Description of changes:*
This PR is to make RPM ARM64 with integTest running on new runner

*Test Results:*
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/541914789

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
