### PR TITLE
Disable schedule run of check plugin workflow

### DIFF
--- a/.github/workflows/check-plugin.yml
+++ b/.github/workflows/check-plugin.yml
@@ -1,8 +1,8 @@
 name: Check Plugin Availability Main
 
 on:
-  schedule:
-    - cron: '0 0,15 * * *'
+#  schedule:
+#    - cron: '0 0,15 * * *'
   repository_dispatch:
     types: [check-plugin]
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Disable schedule run of check plugin workflow

*Test Results:*
No test needed. 

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
