### PR TITLE
Remove needs for tar x64 integTests

### DIFF
--- a/.github/workflows/staging-test-tar-arm64.yml
+++ b/.github/workflows/staging-test-tar-arm64.yml
@@ -45,8 +45,6 @@ jobs:
           RUNNERS+="odfe-tar-sql-arm64,odfe-tar-ad-arm64,odfe-tar-im-arm64,odfe-tar-alerting-arm64"
           release-tools/scripts/setup_runners.sh run $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }} ami-055197d43e4ec7482
 
-
-
   Test-IM-NoSec:
     needs: [Provision-Runners]
     runs-on: [self-hosted, Linux, ARM64, odfe-tar-im-nosec-arm64]

--- a/.github/workflows/staging-test-tar-x64.yml
+++ b/.github/workflows/staging-test-tar-x64.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   Test-ISM-NoSec:
-    needs: [build-es-artifacts]
     runs-on: ubuntu-18.04
     name: Test-ISM-NoSec
     strategy:
@@ -43,7 +42,6 @@ jobs:
           ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest
 
   Test-Alerting-NoSec:
-    needs: [build-es-artifacts]
     runs-on: ubuntu-18.04
     name: Test-Alerting-NoSec
     strategy:
@@ -78,7 +76,6 @@ jobs:
           ../gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest
 
   Test-SQL-NoSec:
-    needs: [build-es-artifacts]
     runs-on: ubuntu-18.04
     name: Test-SQL-NoSec
     strategy:
@@ -113,7 +110,6 @@ jobs:
           ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest
           
   Test-KNN-NoSec:
-    needs: [build-es-artifacts]
     runs-on: ubuntu-18.04
     name: Test-KNN-NoSec
     strategy:
@@ -148,7 +144,6 @@ jobs:
           ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest
           
   Test-AD-NoSec:
-    needs: [build-es-artifacts]
     runs-on: ubuntu-18.04
     name: Test-AD-NoSec
     strategy:
@@ -183,7 +178,6 @@ jobs:
           ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest"
 
   Test-SQL:
-    needs: [build-es-artifacts]
     runs-on: ubuntu-18.04
     name: Test-SQL
     strategy:
@@ -218,7 +212,6 @@ jobs:
           ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest -Dhttps=true -Duser=admin -Dpassword=admin
   
   Test-AD:
-    needs: [build-es-artifacts]
     runs-on: ubuntu-18.04
     name: Test-AD
     strategy:
@@ -253,7 +246,6 @@ jobs:
           ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest" -Dhttps=true -Duser=admin -Dpassword=admin
   
   Test-ALERTING:
-    needs: [build-es-artifacts]
     runs-on: [ubuntu-18.04]
     name: Test-ALERTING
     strategy:
@@ -291,7 +283,6 @@ jobs:
           ../gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest -Dhttps=true -Duser=admin -Dpassword=admin -Dsecurity=true
                
   Test-AD-KIBANA-NoSec:
-    needs: [build-es-artifacts, build-kibana-artifacts]
     runs-on: [ubuntu-16.04]
     name: Test-AD-KIBANA-NoSec
     strategy:
@@ -365,7 +356,6 @@ jobs:
           command: yarn cy:run --config baseurl=http://localhost:5601
     
   Test-SQL-KIBANA-NoSec:
-    needs: [build-es-artifacts, build-kibana-artifacts]
     runs-on: [ubuntu-16.04]
     name: Test-SQL-KIBANA-NoSec
     strategy:
@@ -455,7 +445,6 @@ jobs:
           command: npx cypress run
 
   Test-Kibana-Notebooks-NoSec:
-    needs: [build-es-artifacts, build-kibana-artifacts]
     runs-on: [ubuntu-18.04]
     name: Test-Kibana-Notebooks-NoSec
     strategy:
@@ -532,7 +521,6 @@ jobs:
           command: npx cypress run
 
   Test-AD-KIBANA:
-    needs: [build-es-artifacts, build-kibana-artifacts]
     runs-on: [ubuntu-16.04]
     name: Test-AD-KIBANA
     strategy:
@@ -606,7 +594,6 @@ jobs:
           command: yarn cy:run-with-security --config baseurl=http://localhost:5601
 
   Test-SEC-KIBANA:
-    needs: [build-es-artifacts, build-kibana-artifacts]
     runs-on: [ubuntu-18.04]
     name: Test-SEC-KIBANA
     strategy:


### PR DESCRIPTION
*Issue #, if available:*
V313270097

*Description of changes:*
This PR is to remove needs for tar x64 integTests

*Test Results:*
No Need.

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
