### PR TITLE
Add missing deb/rpm in the manifest for knnlib

### DIFF
--- a/release-tools/scripts/manifest.yml
+++ b/release-tools/scripts/manifest.yml
@@ -161,7 +161,7 @@ plugins:
     plugin_git: opendistro-for-elasticsearch/k-NN
     plugin_version: 1.13.0.0
     plugin_build: 
-    plugin_spec: [linux_x64_zip,linux_x64_deb,linux_x64_rpm,linux_arm64_zip]
+    plugin_spec: [linux_x64_zip,linux_x64_deb,linux_x64_rpm,linux_arm64_zip,linux_arm64_deb,linux_arm64_rpm]
     plugin_category: opendistro-libs
     release_candidate: true
     plugin_location_staging: [default: "s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/opendistro-libs/knnlib/"]


### PR DESCRIPTION
*Issue #, if available:*
V313270097

*Description of changes:*
This PR is to add missing deb/rpm in the manifest for knnlib

*Test Results:*
No Need.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
