### PR TITLE
Add single AZ config to increase response time in test clusters

### DIFF
--- a/.github/workflows/test-cluster-static-domain-set-up.yml
+++ b/.github/workflows/test-cluster-static-domain-set-up.yml
@@ -13,6 +13,9 @@ on:
   #   - cron: '0 11 * * *'
   repository_dispatch:
     types: [test-cluster-static-domain-set-up]
+  push:
+    branches:
+      - "az"
 
 jobs:
   Create-Cluster:

--- a/.github/workflows/test-cluster-static-domain-set-up.yml
+++ b/.github/workflows/test-cluster-static-domain-set-up.yml
@@ -105,14 +105,14 @@ jobs:
               stackName=ODFE-$DISTRIBUTION_TYPE-$ARCHITECTURE-SECURITY-$SECURITY
               echo $stackName
               stack_setup $DISTRIBUTION_TYPE $SECURITY $ARCHITECTURE
-            elif ${{ github.event_name == 'schedule' }}
+            elif ${{ github.event_name == 'schedule' }} || ${{ github.event_name == 'push' }}
             then
               # Add the ditributions and architectures in the below array. All CAPS
-              ARCHITECTURE=(X64 ARM64)
+              ARCHITECTURE=(X64)
               for arch in ${ARCHITECTURE[@]}; do
                   SECURITY=(ENABLE DISABLE)
                   for sec in ${SECURITY[@]}; do
-                      DISTRIBUTION_TYPE=(TAR RPM DEB)
+                      DISTRIBUTION_TYPE=(TAR)
                       for dis in ${DISTRIBUTION_TYPE[@]}; do    
                         stackName=ODFE-$dis-$arch-SECURITY-$sec
                         echo "$stackName in process"

--- a/.github/workflows/test-cluster-static-domain-set-up.yml
+++ b/.github/workflows/test-cluster-static-domain-set-up.yml
@@ -111,11 +111,11 @@ jobs:
             elif ${{ github.event_name == 'schedule' }} || ${{ github.event_name == 'push' }}
             then
               # Add the ditributions and architectures in the below array. All CAPS
-              ARCHITECTURE=(X64)
+              ARCHITECTURE=(X64 ARM64)
               for arch in ${ARCHITECTURE[@]}; do
                   SECURITY=(ENABLE DISABLE)
                   for sec in ${SECURITY[@]}; do
-                      DISTRIBUTION_TYPE=(TAR)
+                      DISTRIBUTION_TYPE=(TAR DEB RPM)
                       for dis in ${DISTRIBUTION_TYPE[@]}; do    
                         stackName=ODFE-$dis-$arch-SECURITY-$sec
                         echo "$stackName in process"

--- a/.github/workflows/test-cluster-static-domain-set-up.yml
+++ b/.github/workflows/test-cluster-static-domain-set-up.yml
@@ -13,9 +13,6 @@ on:
   #   - cron: '0 11 * * *'
   repository_dispatch:
     types: [test-cluster-static-domain-set-up]
-  push:
-    branches:
-      - "az"
 
 jobs:
   Create-Cluster:
@@ -108,7 +105,7 @@ jobs:
               stackName=ODFE-$DISTRIBUTION_TYPE-$ARCHITECTURE-SECURITY-$SECURITY
               echo $stackName
               stack_setup $DISTRIBUTION_TYPE $SECURITY $ARCHITECTURE
-            elif ${{ github.event_name == 'schedule' }} || ${{ github.event_name == 'push' }}
+            elif ${{ github.event_name == 'schedule' }}
             then
               # Add the ditributions and architectures in the below array. All CAPS
               ARCHITECTURE=(X64 ARM64)

--- a/release-tools/templates/odfe-testing-cluster-static-domain-template.json
+++ b/release-tools/templates/odfe-testing-cluster-static-domain-template.json
@@ -58,9 +58,9 @@
     
     "Mappings" : {
         "DistributionMap" : {
-          "RPM" : {"ARM64": "ami-05c53e3ce52089c5c", "X64" : "ami-0e999cbd62129e3b1"},
-          "TAR" : {"ARM64": "ami-09e38cf07be65a594", "X64" : "ami-0ac73f33a1888c64a"},
-          "DEB" : {"ARM64": "ami-09e38cf07be65a594", "X64" : "ami-0ac73f33a1888c64a"}
+          "TAR" : {"ARM64": "ami-09e38cf07be65a594", "X64" : "ami-0ac73f33a1888c64a", "zone": "us-west-2a"},
+          "DEB" : {"ARM64": "ami-09e38cf07be65a594", "X64" : "ami-0ac73f33a1888c64a", "zone": "us-west-2b"},
+          "RPM" : {"ARM64": "ami-05c53e3ce52089c5c", "X64" : "ami-0e999cbd62129e3b1", "zone": "us-west-2c"}
         },
         "InstanceTypeMap": {
             "ARM64" : {"Type": "m6g.xlarge"},
@@ -73,7 +73,7 @@
         "ODFEASG" : {
             "Type" : "AWS::AutoScaling::AutoScalingGroup",
             "Properties" : {
-                "AvailabilityZones" : [ "us-west-2a","us-west-2b","us-west-2c","us-west-2d"  ],
+                "AvailabilityZones" : [ { "Fn::FindInMap" : [ "DistributionMap", { "Ref" : "distribution" }, "zone"]} ],
                 "LaunchConfigurationName" : { "Ref" : "asgLaunchConfig" },
                 "MinSize" : "1",
                 "MaxSize" : "1",
@@ -85,6 +85,7 @@
                         "Fn::Join": [
                           "", ["ODFE-",
                             {"Ref": "distribution"},
+                            {"Ref": "architecture"},
                             "-SECURITY-",
                             {"Ref": "security"},
                             "-Testing-Cluster"]


### PR DESCRIPTION
*Issue #, if available:*
P44184603

*Description of changes:*
Having muti-AZ config on load balancers lead to delay in response time as there are no active instances in that AZ. Hence hard-coding the AZ as per distribution

*Test Results:*
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/549790286

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
