### PR TITLE
[WIP] Rename opendistro_security to opendistro-security in build repo

### DIFF
--- a/elasticsearch/docker/build/elasticsearch/bin/docker-entrypoint.sh
+++ b/elasticsearch/docker/build/elasticsearch/bin/docker-entrypoint.sh
@@ -82,10 +82,13 @@ if [[ "$(id -u)" == "0" ]]; then
     fi
 fi
 
-if [[ -d "/usr/share/elasticsearch/plugins/opendistro_security" && "$DISABLE_INSTALL_DEMO_CONFIG" != "true" ]]; then
+SECURITY_PLUGIN=`ls -p /usr/share/elasticsearch/plugins/ | grep security`
+echo "SECURITY_PLUGIN $SECURITY_PLUGIN"
+
+if [[ -d "/usr/share/elasticsearch/plugins/$SECURITY_PLUGIN" && "$DISABLE_INSTALL_DEMO_CONFIG" != "true" ]]; then
     # Install Demo certifactes for Security Plugin and update the elasticsearch.yml
     # file to use those certificates.
-    /usr/share/elasticsearch/plugins/opendistro_security/tools/install_demo_configuration.sh -y -i -s
+    /usr/share/elasticsearch/plugins/$SECURITY_PLUGIN/tools/install_demo_configuration.sh -y -i -s
 fi
 
 if [[ -d "/usr/share/elasticsearch/plugins/opendistro_performance_analyzer" ]]; then

--- a/elasticsearch/linux_distributions/opendistro-tar-install.sh
+++ b/elasticsearch/linux_distributions/opendistro-tar-install.sh
@@ -16,7 +16,9 @@
 ES_HOME=`dirname $(realpath $0)`; cd $ES_HOME
 ES_KNN_LIB_DIR=$ES_HOME/plugins/opendistro-knn/knn-lib
 ##Security Plugin
-bash $ES_HOME/plugins/opendistro_security/tools/install_demo_configuration.sh -y -i -s
+SECURITY_PLUGIN=`ls -p $ES_HOME/plugins/ | grep security`
+echo "SECURITY_PLUGIN $SECURITY_PLUGIN"
+bash $ES_HOME/plugins/$SECURITY_PLUGIN/tools/install_demo_configuration.sh -y -i -s
 
 ##Perf Plugin
 chmod 755 $ES_HOME/plugins/opendistro_performance_analyzer/pa_bin/performance-analyzer-agent

--- a/elasticsearch/windows/opendistro-windows-build.sh
+++ b/elasticsearch/windows/opendistro-windows-build.sh
@@ -89,7 +89,10 @@ done
 echo "List available plugins"
 ls -l $WORK_DIR/plugins
 
-bash $WORK_DIR/plugins/opendistro_security/tools/install_demo_configuration.sh -y -i -s
+# Security Plugin
+SECURITY_PLUGIN=`ls -p $WORK_DIR/plugins/ | grep security`
+echo "SECURITY_PLUGIN $SECURITY_PLUGIN"
+bash $WORK_DIR/plugins/$SECURITY_PLUGIN/tools/install_demo_configuration.sh -y -i -s
 
 # Making zip
 echo "Generating zip"

--- a/helm/README.md
+++ b/helm/README.md
@@ -252,7 +252,7 @@ you can define secrets that map to each config given that each secret contains t
 ```
 securityConfig:
   enabled: true
-  path: "/usr/share/elasticsearch/plugins/opendistro_security/securityconfig"
+  path: "/usr/share/elasticsearch/plugins/opendistro-security/securityconfig"
   actionGroupsSecret:
   configSecret:
   internalUsersSecret:
@@ -284,7 +284,7 @@ or You can specify  all the security configurations in the values.yaml file  as
 ```
 securityConfig:
   enabled: true
-  path: "/usr/share/elasticsearch/plugins/opendistro_security/securityconfig"
+  path: "/usr/share/elasticsearch/plugins/opendistro-security/securityconfig"
   securityConfigSecret:
   data: {}
     # config.yml: |-
@@ -347,7 +347,7 @@ elasticsearch:
 
   securityConfig:
     enabled: true
-    path: "/usr/share/elasticsearch/plugins/opendistro_security/securityconfig"
+    path: "/usr/share/elasticsearch/plugins/opendistro-security/securityconfig"
     configSecret: "security-config"
     rolesSecret: "roles-config"
     rolesMappingSecret: "roles-mapping-config"
@@ -514,7 +514,7 @@ The following table lists the configurable parameters of the opendistro elastics
 | `kibana.startupProbe`                                    | Configuration for the [startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)                     | `[]`                                                                    |
 | `elasticsearch.discoveryOverride`                         | For hot/warm architectures. Allows second aliased deployment to find cluster.                                                                            | `""`                                                                    |
 | `elasticsearch.securityConfig.enabled`                    | Use custom [security configs](https://github.com/opendistro-for-elasticsearch/security/tree/master/securityconfig)                                       | `"true"`                                                                |
-| `elasticsearch.securityConfig.path`                       | Path to security config files                                                                                                                            | `"/usr/share/elasticsearch/plugins/opendistro_security/securityconfig"` |
+| `elasticsearch.securityConfig.path`                       | Path to security config files                                                                                                                            | `"/usr/share/elasticsearch/plugins/opendistro-security/securityconfig"` |
 | `elasticsearch.securityConfig.actionGroupsSecret`         | Name of secret with [action_groups.yml](https://github.com/opendistro-for-elasticsearch/security/blob/master/securityconfig/action_groups.yml) defined   | `""`                                                                    |
 | `elasticsearch.securityConfig.configSecret`               | Name of secret with [config.yml](https://github.com/opendistro-for-elasticsearch/security/blob/master/securityconfig/config.yml) defined                 | `""`                                                                    |
 | `elasticsearch.securityConfig.internalUsersSecret`        | Name of secret with [internal_users.yml](https://github.com/opendistro-for-elasticsearch/security/blob/master/securityconfig/internal_users.yml) defined | `""`                                                                    |

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -162,7 +162,7 @@ elasticsearch:
   discoveryOverride: ""
   securityConfig:
     enabled: true
-    path: "/usr/share/elasticsearch/plugins/opendistro_security/securityconfig"
+    path: "/usr/share/elasticsearch/plugins/opendistro-security/securityconfig"
     actionGroupsSecret:
     configSecret:
     internalUsersSecret:

--- a/release-tools/scripts/setup_runners_service.sh
+++ b/release-tools/scripts/setup_runners_service.sh
@@ -190,17 +190,17 @@ then
   if [ "$SETUP_DISTRO" = "zip" ]
   then
     sed -i /install_demo_configuration/d $ES_ROOT/opendistro-tar-install.sh
-    $ES_ROOT/bin/elasticsearch-plugin remove opendistro_security
+    $ES_ROOT/bin/elasticsearch-plugin remove opendistro-security
     ls -l $ES_ROOT/plugins
     sed -i '/http\.port/s/^# *//' $ES_ROOT/config/elasticsearch.yml
   elif [ "$SETUP_DISTRO" = "docker" ]
   then
-    echo "RUN /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security" >> Dockerfile
+    echo "RUN /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-security" >> Dockerfile
     echo "RUN ls -l /usr/share/elasticsearch/plugins"
     docker build -t odfe-http:no-security -f Dockerfile .
     sleep 5
   else
-    sudo /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security
+    sudo /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-security
     ls -l /usr/share/elasticsearch/plugins
     sudo sed -i '/http\.port/s/^# *//' /etc/elasticsearch/elasticsearch.yml
     sudo sed -i /^opendistro_security/d /etc/elasticsearch/elasticsearch.yml

--- a/release-tools/scripts/setup_runners_service_windows.ps1
+++ b/release-tools/scripts/setup_runners_service_windows.ps1
@@ -81,7 +81,7 @@ if ($SETUP_ACTION -eq "--es"){
 if ($SETUP_ACTION -eq "--es-nosec" -Or $SETUP_ACTION -eq "--kibana-nosec"){
   echo "removing es security"
   cd $PACKAGE-$OD_VERSION\bin
-  .\elasticsearch-plugin.bat remove opendistro_security
+  .\elasticsearch-plugin.bat remove "opendistro-security"
   cd ..\..
 
   echo "Overriding with elasticsearch.yml having no certificates"

--- a/release-tools/scripts/userdata.sh
+++ b/release-tools/scripts/userdata.sh
@@ -172,7 +172,7 @@ EOF
 else
 sed -i "s/^echo \"cluster.name.*/echo \"cluster.name \: odfe-$OD_VERSION-$1-$ARCHITECTURE-noauth\" \>\> config\/elasticsearch.yml/g" $REPO_ROOT/userdata_$1.sh
 cat <<- EOF >> userdata_$1.sh
-sudo rm -rf plugins/opendistro_security
+sudo rm -rf plugins/opendistro-security
 ls -l plugins/
 sed -i /^opendistro_security/d config/elasticsearch.yml
 cd /opendistroforelasticsearch-kibana/


### PR DESCRIPTION
*Issue #, if available:*
V313270097

*Description of changes:*
This PR is to rename opendistro_security to opendistro-security in build repo
We will only merge this PR if the security PR is merged: https://github.com/opendistro-for-elasticsearch/security/pull/1030

*Test Results:*
No Need.

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
