### PR TITLE
Remove situp from daily scan and add go version 1.14 for whitesource scanning 

### DIFF
--- a/.github/workflows/check-vulnerability-whitesource.yml
+++ b/.github/workflows/check-vulnerability-whitesource.yml
@@ -1,10 +1,12 @@
 name: WhiteSource Vulnerability Scan
 
 on:
-  schedule:
-    - cron: '30 10 * * *'
-  repository_dispatch:
-    types: [check-vulnerability-whitesource]
+#  schedule:
+#    - cron: '30 10 * * *'
+#  repository_dispatch:
+#    types: [check-vulnerability-whitesource]
+  push:
+    branches: [sreekarj_whitesource]
 
 jobs:
   Provision-Runners:
@@ -21,7 +23,7 @@ jobs:
       - name: AWS Cli Processing
         run: |
           RUNNERS="odfe-wss-scan"
-          release-tools/scripts/setup_runners.sh run $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }} ami-086e8a98280780e63
+          release-tools/scripts/setup_runners.sh run $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }} ami-0bd968fea932935f4
 
   whitesource-vulnerability-scan:
     needs: [Provision-Runners]
@@ -33,12 +35,17 @@ jobs:
       fail-fast: false
       matrix:
         java: [11]
+        go-version: [1.14]
     steps:
       - uses: actions/checkout@v1
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
       - name: Vulnerability Scan
         id: vulnerability_scan
         env:

--- a/.github/workflows/check-vulnerability-whitesource.yml
+++ b/.github/workflows/check-vulnerability-whitesource.yml
@@ -83,7 +83,8 @@ jobs:
           password: ${{secrets.MAIL_PASSWORD}}
           subject: ODFE Vulnerability and License Scan - Daily Run
           body: ${{needs.whitesource-vulnerability-scan.outputs.mail_content_output}}
-          to: odfe-infra-team@amazon.com,mmakaria@amazon.com
+#          to: odfe-infra-team@amazon.com,mmakaria@amazon.com
+          to: sreekarj@amazon.com
           from: Opendistro Elasticsearch
           content_type: text/html
 

--- a/.github/workflows/check-vulnerability-whitesource.yml
+++ b/.github/workflows/check-vulnerability-whitesource.yml
@@ -1,12 +1,10 @@
 name: WhiteSource Vulnerability Scan
 
 on:
-#  schedule:
-#    - cron: '30 10 * * *'
-#  repository_dispatch:
-#    types: [check-vulnerability-whitesource]
-  push:
-    branches: [sreekarj_whitesource]
+  schedule:
+    - cron: '30 10 * * *'
+  repository_dispatch:
+    types: [check-vulnerability-whitesource]
 
 jobs:
   Provision-Runners:
@@ -83,8 +81,7 @@ jobs:
           password: ${{secrets.MAIL_PASSWORD}}
           subject: ODFE Vulnerability and License Scan - Daily Run
           body: ${{needs.whitesource-vulnerability-scan.outputs.mail_content_output}}
-#          to: odfe-infra-team@amazon.com,mmakaria@amazon.com
-          to: sreekarj@amazon.com
+          to: odfe-infra-team@amazon.com,mmakaria@amazon.com
           from: Opendistro Elasticsearch
           content_type: text/html
 

--- a/standalone-tools/wss-scan.config
+++ b/standalone-tools/wss-scan.config
@@ -1,3 +1,3 @@
 baseDirPath=$(pwd)
 gitBasePath=https://github.com/opendistro-for-elasticsearch/
-gitRepos=alerting,simple-ingest-transformation-utility-pipeline,opendistro-build,security,performance-analyzer-rca,anomaly-detection,index-management,security-kibana-plugin,sql,job-scheduler,performance-analyzer,index-management-kibana-plugin,alerting-kibana-plugin,common-utils,k-NN,anomaly-detection-kibana-plugin,perftop,kibana-notebooks,kibana-reports,kibana-visualizations,trace-analytics,data-prepper,odfe-cli,asynchronous-search
+gitRepos=alerting,opendistro-build,security,performance-analyzer-rca,anomaly-detection,index-management,security-kibana-plugin,sql,job-scheduler,performance-analyzer,index-management-kibana-plugin,alerting-kibana-plugin,common-utils,k-NN,anomaly-detection-kibana-plugin,perftop,kibana-notebooks,kibana-reports,kibana-visualizations,trace-analytics,data-prepper,odfe-cli,asynchronous-search

--- a/standalone-tools/wss-unified-agent.config
+++ b/standalone-tools/wss-unified-agent.config
@@ -151,6 +151,9 @@ maven.ignoredScopes=None
 npm.resolveDependencies=true
 npm.runPreStep=true
 npm.yarnProject=true
+go.collectDependenciesAtRuntime=true
+go.dependencyManager=modules
+go.resolveDependencies=true
 
 #gradle.ignoredScopes=
 #gradle.resolveDependencies=true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove situp from daily scan and add go version 1.14 for whitesource scanning. 

*Test Results:*
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/572463631


By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
    
