### PR TITLE
Provide UID override functionality via environment variable

### DIFF
--- a/elasticsearch/docker/build/elasticsearch/bin/docker-entrypoint.sh
+++ b/elasticsearch/docker/build/elasticsearch/bin/docker-entrypoint.sh
@@ -7,7 +7,7 @@ umask 0002
 run_as_other_user_if_needed() {
     if [[ "$(id -u)" == "0" ]]; then
         # If running as root, drop to specified UID and run command
-        exec chroot --userspec=1000 / "${@}"
+        exec chroot --userspec=${PUID:-${DEFAULT_UID}} / "${@}"
     else
         # Either we are running in Openshift with random uid and are a member of the root group
         # or with a custom --user
@@ -30,8 +30,8 @@ if [[ "$1" != "eswrapper" ]]; then
         # Without this, user could specify `elasticsearch -E x.y=z` but
         # `bin/elasticsearch -E x.y=z` would not work.
         set -- "elasticsearch" "${@:2}"
-        # Use chroot to switch to UID 1000
-        exec chroot --userspec=1000 / "$@"
+        # Use chroot to switch to non-root UID
+        exec chroot --userspec=${PUID:-${DEFAULT_UID}} / "$@"
     else
         # User probably wants to run something else, like /bin/bash, with another uid forced (Openshift?)
         exec "$@"
@@ -78,7 +78,7 @@ export ES_JAVA_OPTS="-Des.cgroups.hierarchy.override=/ $ES_JAVA_OPTS"
 if [[ "$(id -u)" == "0" ]]; then
     # If requested and running as root, mutate the ownership of bind-mounts
     if [[ -n "$TAKE_FILE_OWNERSHIP" ]]; then
-        chown -R 1000:0 /usr/share/elasticsearch/{data,logs}
+        chown -R ${PUID:-${DEFAULT_UID}}:0 /usr/share/elasticsearch/{data,logs}
     fi
 fi
 
@@ -92,9 +92,11 @@ if [[ -d "/usr/share/elasticsearch/plugins/opendistro-performance-analyzer" ]]; 
     CLK_TCK=`/usr/bin/getconf CLK_TCK`
     ES_JAVA_OPTS="-Dclk.tck=$CLK_TCK -Djdk.attach.allowAttachSelf=true $ES_JAVA_OPTS"
     if [[ -d "/usr/share/elasticsearch/performance-analyzer-rca" ]]; then
+        sed -i "s/^user=.*/user=${PUID:-${DEFAULT_UID}}/" /usr/share/elasticsearch/performance-analyzer-rca/pa_config/supervisord.conf
         ES_JAVA_OPTS="-Djava.security.policy=file:///usr/share/elasticsearch/performance-analyzer-rca/pa_config/es_security.policy $ES_JAVA_OPTS"
         /usr/bin/supervisord -c /usr/share/elasticsearch/performance-analyzer-rca/pa_config/supervisord.conf
     else
+        sed -i "s/^user=.*/user=${PUID:-${DEFAULT_UID}}/" /usr/share/elasticsearch/plugins/opendistro-performance-analyzer/pa_config/supervisord.conf
         ES_JAVA_OPTS="-Djava.security.policy=file:///usr/share/elasticsearch/plugins/opendistro-performance-analyzer/pa_config/es_security.policy $ES_JAVA_OPTS"
         /usr/bin/supervisord -c /usr/share/elasticsearch/plugins/opendistro-performance-analyzer/pa_config/supervisord.conf
     fi

--- a/elasticsearch/docker/templates/Dockerfile.j2
+++ b/elasticsearch/docker/templates/Dockerfile.j2
@@ -47,12 +47,17 @@ RUN yum -y update \
     && yum install -y unzip glibc.x86_64 cmake \
     && yum clean all
 
-RUN groupadd -g 1000 elasticsearch && \
-    adduser -u 1000 -g 1000 -d /usr/share/elasticsearch elasticsearch
+ARG DEFAULT_UID=1000
+ARG DEFAULT_GID=1000
+ENV DEFAULT_UID $DEFAULT_UID
+ENV DEFAULT_GID $DEFAULT_GID
 
-USER 1000
+RUN groupadd -g $DEFAULT_GID elasticsearch && \
+    adduser -u $DEFAULT_UID -g $DEFAULT_GID -d /usr/share/elasticsearch elasticsearch
+
+USER $DEFAULT_UID
 {% if artifacts_dir %}
-COPY --chown=1000:0 {{ '%s/' % artifacts_dir }} {{ artifacts_dir }}
+COPY --chown=$DEFAULT_UID:0 {{ '%s/' % artifacts_dir }} {{ artifacts_dir }}
 {% endif %}
 
 RUN rm -rf /tmp/plugins && mkdir /tmp/plugins
@@ -79,7 +84,7 @@ ENV PATH $PATH:$JAVA_HOME/bin
 RUN java -version && echo CURR_DIR && pwd
 
 # Compile the C-library for kNN
-USER 1000
+USER $DEFAULT_UID
 RUN set -ex; \
     export KNN_VERSION=`git ls-remote --tags "https://github.com/opendistro-for-elasticsearch/k-NN" v* | grep $(echo {{version_tag}} | sed -E "s/.[0-9]+$//g") | grep -oh "v[0-9.]*" | sort | tail -n 1` \
     && git ls-remote --tags https://github.com/opendistro-for-elasticsearch/k-NN.git v* \
@@ -115,7 +120,7 @@ RUN security=`ls -p plugins/ | grep security` && \
     if [ ! -z "$security" ]; then chmod +x plugins/$security/tools/install_demo_configuration.sh; echo "Security plugin installed"; \
     else echo "Security plugin is not yet installed"; fi
 
-COPY --chown=1000:0 elasticsearch.yml log4j2.properties config/
+COPY --chown=$DEFAULT_UID:0 elasticsearch.yml log4j2.properties config/
 
 USER 0
 
@@ -123,7 +128,7 @@ USER 0
 RUN chown -R elasticsearch:0 . && \
     chmod -R g=u /usr/share/elasticsearch
 
-RUN pfa=`ls -p plugins/ | grep performance` && \ 
+RUN pfa=`ls -p plugins/ | grep performance` && \
     if [ ! -z "$pfa" ]; then chmod 755 plugins/$pfa/pa_bin/performance-analyzer-agent; echo "Performance Analyzer plugin installed"; \
     else echo "Performace Analyzer plugin is not yet installed"; fi
 
@@ -137,6 +142,11 @@ RUN chmod -R 755 /dev/shm
 FROM centos:7
 
 ENV ELASTIC_CONTAINER true
+
+ARG DEFAULT_UID=1000
+ARG DEFAULT_GID=1000
+ENV DEFAULT_UID $DEFAULT_UID
+ENV DEFAULT_GID $DEFAULT_GID
 
 RUN \
   rpm --rebuilddb && yum clean all && \
@@ -158,9 +168,9 @@ RUN yum update -y && \
     yum install -y nc unzip wget which && \
     yum clean all
 COPY CENTOS_LICENSING.txt /root
-##COPY --from=prep_es_files --chown=1000:0 /opt/jdk-12.0.2 /opt/jdk-12.0.2
+##COPY --from=prep_es_files --chown=$DEFAULT_UID:0 /opt/jdk-12.0.2 /opt/jdk-12.0.2
 
-COPY --from=prep_es_files --chown=1000:0 /opt/jdk /opt/jdk
+COPY --from=prep_es_files --chown=$DEFAULT_UID:0 /opt/jdk /opt/jdk
 ENV JAVA_HOME /opt/jdk
 ENV PATH $PATH:$JAVA_HOME/bin
 RUN java -version
@@ -172,21 +182,21 @@ RUN ln -sf /etc/pki/ca-trust/extracted/java/cacerts $JAVA_HOME/lib/security/cace
 
 
 RUN mkdir /usr/share/elasticsearch && \
-    groupadd -g 1000 elasticsearch && \
-    adduser -u 1000 -g 1000 -G 0 -d /usr/share/elasticsearch elasticsearch && \
+    groupadd -g $DEFAULT_GID elasticsearch && \
+    adduser -u $DEFAULT_UID -g $DEFAULT_GID -G 0 -d /usr/share/elasticsearch elasticsearch && \
     chmod 0775 /usr/share/elasticsearch && \
     chgrp 0 /usr/share/elasticsearch
 
 RUN mkdir -p /usr/share/supervisor/performance_analyzer/ && \
-    chown 1000 /usr/share/supervisor/performance_analyzer
+    chown $DEFAULT_UID /usr/share/supervisor/performance_analyzer
 
 WORKDIR /usr/share/elasticsearch
-COPY --from=prep_es_files --chown=1000:0 /usr/share/elasticsearch /usr/share/elasticsearch
+COPY --from=prep_es_files --chown=$DEFAULT_UID:0 /usr/share/elasticsearch /usr/share/elasticsearch
 COPY --from=prep_es_files /tmp/jni/libKNNIndex*.so /usr/lib
 
 ENV PATH /usr/share/elasticsearch/bin:$PATH
 
-ADD --chown=1000:0 bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ADD --chown=$DEFAULT_UID:0 bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 # Openshift overrides USER and uses ones with randomly uid>1024 and gid=0
 # Allow ENTRYPOINT (and ES) to run even with a different user

--- a/kibana/docker/templates/Dockerfile.j2
+++ b/kibana/docker/templates/Dockerfile.j2
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Description: 
+# Description:
 # This Dockerfile was generated from the template at templates/Dockerfile.j2
 
 {%   set kibana_url = 'https://artifacts.elastic.co/downloads/kibana' -%}
@@ -22,6 +22,11 @@
 FROM centos:7
 
 ENV ELASTIC_CONTAINER true
+
+ARG DEFAULT_UID=1000
+ARG DEFAULT_GID=1000
+ENV DEFAULT_UID $DEFAULT_UID
+ENV DEFAULT_GID $DEFAULT_GID
 
 RUN yum update -y && yum install -y fontconfig freetype && yum clean all
 
@@ -39,30 +44,30 @@ RUN curl -Ls {{ kibana_url }}/{{ tarball }} | tar --strip-components=1 -zxf - &&
     done && \
     rm -rf /tmp/plugins/ && \
     ln -s /usr/share/kibana /opt/kibana && \
-    chown -R 1000:0 . && \
+    chown -R $DEFAULT_UID:0 . && \
     chmod -R g=u /usr/share/kibana && \
     find /usr/share/kibana -type d -exec chmod g+s {} \;
 
 # Set some Kibana configuration defaults.
-COPY --chown=1000:0 config/kibana.yml /usr/share/kibana/config/kibana.yml
+COPY --chown=$DEFAULT_UID:0 config/kibana.yml /usr/share/kibana/config/kibana.yml
 
 # Add the launcher/wrapper script. It knows how to interpret environment
 # variables and translate them to Kibana CLI options.
-COPY --chown=1000:0 bin/kibana-docker /usr/local/bin/
+COPY --chown=$DEFAULT_UID:0 bin/kibana-docker /usr/local/bin/
 
 # Add a self-signed SSL certificate for use in examples.
-COPY --chown=1000:0 ssl/opendistroforelasticsearch.example.org.* /usr/share/kibana/config/
+COPY --chown=$DEFAULT_UID:0 ssl/opendistroforelasticsearch.example.org.* /usr/share/kibana/config/
 
 # Ensure gid 0 write permissions for Openshift.
 # Provide a non-root user to run the process.
 # Adds CENTOS License text.
 RUN find /usr/share/kibana -gid 0 -and -not -perm /g+w -exec chmod g+w {} \; && \
-    groupadd --gid 1000 kibana && \
-      useradd --uid 1000 --gid 1000 \
+    groupadd --gid $DEFAULT_GID kibana && \
+      useradd --uid $DEFAULT_UID --gid $DEFAULT_GID \
       --home-dir /usr/share/kibana --no-create-home kibana && \
       echo $'= CentOS Licensing and Source Code =\n\nThis image is built from CentOS and DockerHub\'s official build of CentOS (https://hub.docker.com/_/centos). Their image contains various Open Source licensed packages and their DockerHub home page provides information on licensing.\n\nYou can list the packages installed in the image by running \'rpm -qa\', and you can download the source code for the packages CentOS and DockerHub provide via the yumdownloader tool.' > /root/CENTOS_LICENSING.txt
 
-USER 1000
+USER $DEFAULT_UID
 
 LABEL org.label-schema.schema-version="1.0" \
   org.label-schema.vendor="Amazon" \


### PR DESCRIPTION
opendistro-for-elasticsearch/opendistro-build#613

*Description of changes:*

Provide UID override functionality via environment variable ($PUID) as discussed in #613

The Dockerfile templates specify (and accept as build arguments) the variables DEFAULT_UID and DEFAULT_GID which are used for initial user creation and filesystem permissions setup. At runtime on the elasticsearch container, the previously hard-coded value of 1000 has been replaced by ${PUID:-${DEFAULT_UID}}, meaning the default value of 1000 (or whatever DEFAULT_UID was set to when the image was built) will be used, or, if specified via a docker-compose-specified environment variable or docker run-specified environment variable, PUID will be used.

I'll review the changes one by one with the GitHub's code review feature.


By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
    
