### PR TITLE
helm: Use networking.k8s.io/v1beta1 API version for ingresses

### DIFF
--- a/helm/opendistro-es/templates/elasticsearch/es-client-ingress.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-ingress.yaml
@@ -16,7 +16,7 @@
 {{ $fullName := printf "%s-%s"  (include "opendistro-es.fullname" .) "client-service" }}
 {{ $ingressPath := .Values.elasticsearch.client.ingress.path }}
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 metadata:
   name: {{ $fullName }}
   labels:

--- a/helm/opendistro-es/templates/kibana/kibana-ingress.yml
+++ b/helm/opendistro-es/templates/kibana/kibana-ingress.yml
@@ -16,7 +16,7 @@
 {{- $serviceName := printf "%s-%s" (include "opendistro-es.fullname" .) "kibana-svc" }}
 {{- $servicePort := .Values.kibana.externalPort }}
 {{- $ingressPath := .Values.kibana.ingress.path }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "opendistro-es.fullname" . }}-kibana-ing


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Updates the API version for both the Kibana and Elasticsearch ingresses.

From https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
_The v1.22 release will stop serving the following deprecated API versions in favor of newer and more stable API versions:_

- _Ingress in the extensions/v1beta1 API version will no longer be served_
  - _Migrate to use the networking.k8s.io/v1beta1 API version, available since v1.14. Existing persisted data can be retrieved/updated via the new version._

This is just a small bump as the API version is already deprecated in v1.19+
> Warning: networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress

but I guess it's smart to do these changes in smaller steps.

*Test Results:*

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/main/CONTRIBUTING.md#sign-your-work).
