### PR TITLE
Indentation bug fix in values.yaml : Security Configuration

### DIFF
--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -172,13 +172,13 @@ elasticsearch:
     #The following option simplifies securityConfig by using a single secret and specifying the respective secrets in the corresponding files instead of creating different secrets for config,internal users, roles, roles mapping and tenants
     #Note that this is an alternative to the above secrets and shouldn't be used if the above secrets are used
     config:
-       securityConfigSecret:
-       data: {}
-        # config.yml: |-
-        # internal_users.yml: |-
-        # roles.yml: |-
-        # rolesMapping.yml: |-
-        # tenants.yml: |-
+      securityConfigSecret:
+      data: {}
+       # config.yml: |-
+       # internal_users.yml: |-
+       # roles.yml: |-
+       # rolesMapping.yml: |-
+       # tenants.yml: |-
 
   extraEnvs: []
 


### PR DESCRIPTION
*Issue #, if available:*
#687 


*Description of changes:*
Lines 175 to 181 are separated by 3 spaces, so change to 2 spaces.
![스크린샷 2021-03-15 23 09 02](https://user-images.githubusercontent.com/37290743/111167872-e0790f80-85e4-11eb-9dde-54a6814e8f90.png)


*Test Results:*
By configuring Security Configuration normally, it is successful to install helm by configuring oidc backend.


**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/main/CONTRIBUTING.md#sign-your-work).
