### PR TITLE
Add integration test for async plugin with security disabled

### DIFF
--- a/.github/workflows/staging-test-deb-arm64.yml
+++ b/.github/workflows/staging-test-deb-arm64.yml
@@ -25,7 +25,7 @@ jobs:
           # Don't add space after commas
           RUNNERS="odfe-deb-im-nosec-arm64,odfe-deb-alerting-nosec-arm64,odfe-deb-sql-nosec-arm64,odfe-deb-knn-nosec-arm64,odfe-deb-ad-nosec-arm64,"
           RUNNERS+="odfe-deb-sql-arm64,odfe-deb-ad-arm64,odfe-deb-alerting-arm64,"
-          RUNNERS+="odfe-deb-ad-kibana-nosec-arm64,odfe-deb-sql-kibana-nosec-arm64,"
+          RUNNERS+="odfe-deb-ad-kibana-nosec-arm64,odfe-deb-sql-kibana-nosec-arm64,odfe-deb-async-nosec-arm64,"
           RUNNERS+="odfe-deb-ad-kibana-arm64,odfe-deb-sec-kibana-arm64,odfe-deb-kibana-nb-nosec-arm64"
           release-tools/scripts/setup_runners.sh run $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }} ami-03f8a33a16290a84c
 
@@ -128,6 +128,26 @@ jobs:
           release-tools/scripts/setup_runners_service.sh deb --es-nosec arm64
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
           ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest"
+
+  Test-Async-NoSec:
+    needs: [Provision-Runners]
+    name: Test-Async-NoSec
+    runs-on: [self-hosted, Linux, ARM64, odfe-deb-async-nosec-arm64]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Required Packages
+        run: release-tools/scripts/required_packages.sh
+      - name: Retrieve plugin tags
+        run: echo "p_tag_async=$(release-tools/scripts/plugin_tag.sh opendistro-for-elasticsearch/asynchronous-search)" >> $GITHUB_ENV
+      - uses: actions/checkout@v1
+        with:
+          repository: opendistro-for-elasticsearch/asynchronous-search
+          ref: ${{env.p_tag_async}}
+      - name: IT for IM NoSec
+        run: |
+          release-tools/scripts/setup_runners_service.sh deb --es-nosec arm64
+          export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../asynchronous-search; pwd
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest
 
   Test-SQL:
     needs: [Provision-Runners]
@@ -542,7 +562,7 @@ jobs:
           yarn test:jest_server
 
   CleanUp-Runners:
-    needs: [Test-IM-NoSec, Test-ALERTING-NoSec, Test-SQL-NoSec, Test-KNN-NoSec, Test-AD-NoSec, Test-SQL, Test-AD, Test-ALERTING, Test-AD-KIBANA-NoSec, Test-SQL-KIBANA-NoSec, Test-AD-KIBANA, Test-SEC-KIBANA, Test-Kibana-Notebooks-NoSec]
+    needs: [Test-IM-NoSec, Test-ALERTING-NoSec, Test-SQL-NoSec, Test-KNN-NoSec, Test-AD-NoSec, Test-SQL, Test-AD, Test-ALERTING, Test-AD-KIBANA-NoSec, Test-SQL-KIBANA-NoSec, Test-AD-KIBANA, Test-SEC-KIBANA, Test-Kibana-Notebooks-NoSec, Test-Async-NoSec]
     if: always()
     name: CleanUp-Runners
     runs-on: ubuntu-18.04
@@ -561,7 +581,7 @@ jobs:
           # Don't add space after commas
           RUNNERS="odfe-deb-im-nosec-arm64,odfe-deb-alerting-nosec-arm64,odfe-deb-sql-nosec-arm64,odfe-deb-knn-nosec-arm64,odfe-deb-ad-nosec-arm64,"
           RUNNERS+="odfe-deb-sql-arm64,odfe-deb-ad-arm64,odfe-deb-alerting-arm64,"
-          RUNNERS+="odfe-deb-ad-kibana-nosec-arm64,odfe-deb-sql-kibana-nosec-arm64,"
+          RUNNERS+="odfe-deb-ad-kibana-nosec-arm64,odfe-deb-sql-kibana-nosec-arm64,odfe-deb-async-nosec-arm64,"
           RUNNERS+="odfe-deb-ad-kibana-arm64,odfe-deb-sec-kibana-arm64,odfe-deb-kibana-nb-nosec-arm64"
           release-tools/scripts/setup_runners.sh terminate $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }}
 

--- a/.github/workflows/staging-test-deb-x64.yml
+++ b/.github/workflows/staging-test-deb-x64.yml
@@ -163,6 +163,38 @@ jobs:
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
           ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest"
 
+  Test-Async-NoSec:
+    runs-on: [ubuntu-18.04]
+    name: Test-Async-NoSec
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [14]
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Install Required Packages
+        run: release-tools/scripts/required_packages.sh
+ 
+      - name: Retrieve plugin tags 
+        run:  echo "p_tag_async=$(release-tools/scripts/plugin_tag.sh opendistro-for-elasticsearch/asynchronous-search)" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v1
+        with:
+          repository: opendistro-for-elasticsearch/asynchronous-search
+          ref: ${{env.p_tag_async}}
+
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: IT
+        run: |
+          release-tools/scripts/setup_runners_service.sh deb --es-nosec
+          export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../asynchronous-search; pwd
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest
+
   Test-SQL:
     runs-on: [ubuntu-18.04]
     name: Test-SQL

--- a/.github/workflows/staging-test-docker-x64.yml
+++ b/.github/workflows/staging-test-docker-x64.yml
@@ -168,6 +168,38 @@ jobs:
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
           ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest"
 
+  Test-Async-NoSec:
+    runs-on: ubuntu-18.04
+    name: Test-Async-NoSec
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [14]
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Install Required Packages
+        run: release-tools/scripts/required_packages.sh
+ 
+      - name: Retrieve plugin tags 
+        run:  echo "p_tag_async=$(release-tools/scripts/plugin_tag.sh opendistro-for-elasticsearch/asynchronous-search)" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v1
+        with:
+          repository: opendistro-for-elasticsearch/asynchronous-search
+          ref: ${{env.p_tag_async}}
+
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: IT
+        run: |
+          release-tools/scripts/setup_runners_service.sh docker --es-nosec
+          export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../asynchronous-search; pwd
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest
+
   Test-SQL:
     runs-on: ubuntu-18.04
     name: Test-SQL

--- a/.github/workflows/staging-test-rpm-arm64.yml
+++ b/.github/workflows/staging-test-rpm-arm64.yml
@@ -25,7 +25,7 @@ jobs:
           # Don't add space after commas
           RUNNERS="odfe-rpm-im-nosec-arm64,odfe-rpm-alerting-nosec-arm64,odfe-rpm-sql-nosec-arm64,odfe-rpm-knn-nosec-arm64,odfe-rpm-ad-nosec-arm64,"
           RUNNERS+="odfe-rpm-sql-arm64,odfe-rpm-ad-arm64,odfe-rpm-alerting-arm64,"
-          RUNNERS+="odfe-rpm-ad-kibana-nosec-arm64,odfe-rpm-sql-kibana-nosec-arm64,"
+          RUNNERS+="odfe-rpm-ad-kibana-nosec-arm64,odfe-rpm-sql-kibana-nosec-arm64,odfe-rpm-async-nosec-arm64,"
           RUNNERS+="odfe-rpm-ad-kibana-arm64,odfe-rpm-sec-kibana-arm64,odfe-rpm-kibana-nb-nosec-arm64"
           release-tools/scripts/setup_runners.sh run $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }} ami-0ef0c96643bbd01f2
 
@@ -128,6 +128,26 @@ jobs:
           release-tools/scripts/setup_runners_service.sh rpm --es-nosec arm64
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
           ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest"
+
+  Test-Async-NoSec:
+    needs: [Provision-Runners]
+    name: Test-Async-NoSec
+    runs-on: [self-hosted, Linux, ARM64, odfe-rpm-async-nosec-arm64]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Required Packages
+        run: release-tools/scripts/required_packages.sh
+      - name: Retrieve plugin tags
+        run: echo "p_tag_async=$(release-tools/scripts/plugin_tag.sh opendistro-for-elasticsearch/asynchronous-search)" >> $GITHUB_ENV
+      - uses: actions/checkout@v1
+        with:
+          repository: opendistro-for-elasticsearch/asynchronous-search
+          ref: ${{env.p_tag_async}}
+      - name: IT for Async NoSec
+        run: |
+          release-tools/scripts/setup_runners_service.sh rpm --es-nosec arm64
+          export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../asynchronous-search; pwd
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest
 
   Test-SQL:
     needs: [Provision-Runners]
@@ -542,7 +562,7 @@ jobs:
           yarn test:jest_server
 
   CleanUp-Runners:
-    needs: [Test-IM-NoSec, Test-ALERTING-NoSec, Test-SQL-NoSec, Test-KNN-NoSec, Test-AD-NoSec, Test-SQL, Test-AD, Test-ALERTING, Test-AD-KIBANA-NoSec, Test-SQL-KIBANA-NoSec, Test-AD-KIBANA, Test-SEC-KIBANA, Test-Kibana-Notebooks-NoSec]
+    needs: [Test-IM-NoSec, Test-ALERTING-NoSec, Test-SQL-NoSec, Test-KNN-NoSec, Test-AD-NoSec, Test-SQL, Test-AD, Test-ALERTING, Test-AD-KIBANA-NoSec, Test-SQL-KIBANA-NoSec, Test-AD-KIBANA, Test-SEC-KIBANA, Test-Kibana-Notebooks-NoSec, Test-Async-NoSec]
     if: always()
     name: CleanUp-Runners
     runs-on: ubuntu-18.04
@@ -561,7 +581,7 @@ jobs:
           # Don't add space after commas
           RUNNERS="odfe-rpm-im-nosec-arm64,odfe-rpm-alerting-nosec-arm64,odfe-rpm-sql-nosec-arm64,odfe-rpm-knn-nosec-arm64,odfe-rpm-ad-nosec-arm64,"
           RUNNERS+="odfe-rpm-sql-arm64,odfe-rpm-ad-arm64,odfe-rpm-alerting-arm64,"
-          RUNNERS+="odfe-rpm-ad-kibana-nosec-arm64,odfe-rpm-sql-kibana-nosec-arm64,"
+          RUNNERS+="odfe-rpm-ad-kibana-nosec-arm64,odfe-rpm-sql-kibana-nosec-arm64,odfe-rpm-async-nosec-arm64,"
           RUNNERS+="odfe-rpm-ad-kibana-arm64,odfe-rpm-sec-kibana-arm64,odfe-rpm-kibana-nb-nosec-arm64"
           release-tools/scripts/setup_runners.sh terminate $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }}
 

--- a/.github/workflows/staging-test-rpm-x64.yml
+++ b/.github/workflows/staging-test-rpm-x64.yml
@@ -25,7 +25,7 @@ jobs:
           # Don't add space after commas
           RUNNERS="odfe-rpm-im-nosec-x64,odfe-rpm-alerting-nosec-x64,odfe-rpm-sql-nosec-x64,odfe-rpm-knn-nosec-x64,odfe-rpm-ad-nosec-x64,"
           RUNNERS+="odfe-rpm-sql-x64,odfe-rpm-ad-x64,odfe-rpm-alerting-x64,"
-          RUNNERS+="odfe-rpm-ad-kibana-nosec-x64,odfe-rpm-sql-kibana-nosec-x64,"
+          RUNNERS+="odfe-rpm-ad-kibana-nosec-x64,odfe-rpm-sql-kibana-nosec-x64,odfe-rpm-async-nosec-x64,"
           RUNNERS+="odfe-rpm-ad-kibana-x64,odfe-rpm-sec-kibana-x64,odfe-rpm-kibana-nb-nosec-x64,odfe-rpm-alerting-kibana-nosec-x64"
           release-tools/scripts/setup_runners.sh run $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }} ami-0bd968fea932935f4
 
@@ -148,6 +148,30 @@ jobs:
           release-tools/scripts/setup_runners_service.sh rpm --es-nosec
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
           ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest"
+
+  Test-Async-NoSec:
+    needs: [Provision-Runners]
+    name: Test-Async-NoSec
+    runs-on: [self-hosted, Linux, X64, odfe-rpm-async-nosec-x64]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 14
+      - name: Required Packages
+        run: release-tools/scripts/required_packages.sh
+      - name: Retrieve plugin tags
+        run: echo "p_tag_async=$(release-tools/scripts/plugin_tag.sh opendistro-for-elasticsearch/asynchronous-search)" >> $GITHUB_ENV
+      - uses: actions/checkout@v1
+        with:
+          repository: opendistro-for-elasticsearch/asynchronous-search
+          ref: ${{env.p_tag_async}}
+      - name: IT for IM NoSec
+        run: |
+          release-tools/scripts/setup_runners_service.sh rpm --es-nosec
+          export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../asynchronous-search; pwd
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest
 
   Test-SQL:
     needs: [Provision-Runners]
@@ -679,7 +703,7 @@ jobs:
           yarn test:jest_server
 
   CleanUp-Runners:
-    needs: [Test-IM-NoSec, Test-ALERTING-NoSec, Test-SQL-NoSec, Test-KNN-NoSec, Test-AD-NoSec, Test-SQL, Test-AD, Test-ALERTING, Test-AD-KIBANA-NoSec, Test-SQL-KIBANA-NoSec, Test-AD-KIBANA, Test-SEC-KIBANA, Test-Kibana-Notebooks-NoSec, Test-Alerting-Kibana-NoSec]
+    needs: [Test-IM-NoSec, Test-ALERTING-NoSec, Test-SQL-NoSec, Test-KNN-NoSec, Test-AD-NoSec, Test-SQL, Test-AD, Test-ALERTING, Test-AD-KIBANA-NoSec, Test-SQL-KIBANA-NoSec, Test-AD-KIBANA, Test-SEC-KIBANA, Test-Kibana-Notebooks-NoSec, Test-Alerting-Kibana-NoSec, Test-Async-NoSec]
     if: always()
     name: CleanUp-Runners
     runs-on: ubuntu-18.04
@@ -698,7 +722,7 @@ jobs:
           # Don't add space after commas
           RUNNERS="odfe-rpm-im-nosec-x64,odfe-rpm-alerting-nosec-x64,odfe-rpm-sql-nosec-x64,odfe-rpm-knn-nosec-x64,odfe-rpm-ad-nosec-x64,"
           RUNNERS+="odfe-rpm-sql-x64,odfe-rpm-ad-x64,odfe-rpm-alerting-x64,"
-          RUNNERS+="odfe-rpm-ad-kibana-nosec-x64,odfe-rpm-sql-kibana-nosec-x64,"
+          RUNNERS+="odfe-rpm-ad-kibana-nosec-x64,odfe-rpm-sql-kibana-nosec-x64,odfe-rpm-async-nosec-x64,"
           RUNNERS+="odfe-rpm-ad-kibana-x64,odfe-rpm-sec-kibana-x64,odfe-rpm-kibana-nb-nosec-x64,odfe-rpm-alerting-kibana-nosec-x64"
           release-tools/scripts/setup_runners.sh terminate $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }}
 

--- a/.github/workflows/staging-test-tar-arm64.yml
+++ b/.github/workflows/staging-test-tar-arm64.yml
@@ -41,7 +41,7 @@ jobs:
           # Please add comma at the end of the RUNNERS strings
           # Don't add space after commas
           RUNNERS+="odfe-tar-im-nosec-arm64,odfe-tar-alerting-nosec-arm64,odfe-tar-sql-nosec-arm64,odfe-tar-knn-nosec-arm64,odfe-tar-ad-nosec-arm64,"
-          RUNNERS+="odfe-tar-sql-arm64,odfe-tar-ad-arm64,odfe-tar-alerting-arm64"
+          RUNNERS+="odfe-tar-sql-arm64,odfe-tar-ad-arm64,odfe-tar-alerting-arm64,odfe-tar-async-nosec-arm64"
           release-tools/scripts/setup_runners.sh run $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }} ami-03f8a33a16290a84c
 
   Test-IM-NoSec:
@@ -179,6 +179,33 @@ jobs:
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
           ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest"
 
+  Test-Async-NoSec:
+    needs: [Provision-Runners]
+    runs-on: [self-hosted, Linux, ARM64, odfe-tar-async-nosec-arm64]
+    name: Test-Async-NoSec
+    steps:
+      - name: Set up AWS Cred
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - uses: actions/checkout@v1
+      - name: Required Packages
+        run: ./release-tools/scripts/required_packages.sh
+      - name: Retrieve plugin tags
+        run:  echo "p_tag_async=$(release-tools/scripts/plugin_tag.sh opendistro-for-elasticsearch/asynchronous-search)" >> $GITHUB_ENV
+      - name: Checkout IM
+        uses: actions/checkout@v1
+        with:
+          repository: opendistro-for-elasticsearch/asynchronous-search
+          ref: ${{env.p_tag_async}}
+      - name: Integration Test
+        run: |
+          ./release-tools/scripts/setup_runners_service.sh zip --es-nosec arm64
+          export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../asynchronous-search; pwd
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest
+
   Test-SQL:
     needs: [Provision-Runners]
     runs-on: [self-hosted, Linux, ARM64, odfe-tar-sql-arm64]
@@ -262,7 +289,7 @@ jobs:
           ../gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest -Dhttps=true -Duser=admin -Dpassword=admin -Dsecurity=true
 
   CleanUp-Runners:
-    needs: [Test-IM-NoSec, Test-ALERTING-NoSec, Test-SQL-NoSec, Test-KNN-NoSec, Test-AD-NoSec, Test-SQL, Test-AD, Test-ALERTING]
+    needs: [Test-IM-NoSec, Test-ALERTING-NoSec, Test-SQL-NoSec, Test-KNN-NoSec, Test-AD-NoSec, Test-SQL, Test-AD, Test-ALERTING, Test-Async-NoSec]
     if: always()
     name: CleanUp-Runners
     runs-on: ubuntu-18.04
@@ -280,5 +307,5 @@ jobs:
           # Please add comma at the end of the RUNNERS strings
           # Don't add space after commas
           RUNNERS+="odfe-tar-im-nosec-arm64,odfe-tar-alerting-nosec-arm64,odfe-tar-sql-nosec-arm64,odfe-tar-knn-nosec-arm64,odfe-tar-ad-nosec-arm64,"
-          RUNNERS+="odfe-tar-sql-arm64,odfe-tar-ad-arm64,odfe-tar-alerting-arm64"
+          RUNNERS+="odfe-tar-sql-arm64,odfe-tar-ad-arm64,odfe-tar-alerting-arm64,odfe-tar-async-nosec-arm64"
           release-tools/scripts/setup_runners.sh terminate $RUNNERS ${{ secrets.ODFE_RELEASE_BOT_PUBLIC_PRIVATE_READ_WRITE_TOKEN }}  

--- a/.github/workflows/staging-test-tar-macos-x64.yml
+++ b/.github/workflows/staging-test-tar-macos-x64.yml
@@ -177,6 +177,40 @@ jobs:
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
           ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest"
 
+  Test-Async-NoSec:
+    runs-on: macos-latest
+    name: Test-Async-NoSec
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [14]
+    steps:
+      - name: Set up AWS Cred
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - uses: actions/checkout@v1
+      - name: Required Packages
+        run: brew install yq coreutils gnu-sed
+      - name: Retrieve plugin tags
+        run:  echo "p_tag_async=$(release-tools/scripts/plugin_tag.sh opendistro-for-elasticsearch/asynchronous-search)" >> $GITHUB_ENV
+      - name: Checkout IM
+        uses: actions/checkout@v1
+        with:
+          repository: opendistro-for-elasticsearch/asynchronous-search
+          ref: ${{env.p_tag_async}}
+      - name: IT
+        run: |
+          ./release-tools/scripts/setup_runners_service_macos.sh --es-nosec x64
+          export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../asynchronous-search; pwd
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest
+
   Test-SQL:
     runs-on: macos-latest
     name: Test-SQL

--- a/.github/workflows/staging-test-tar-x64.yml
+++ b/.github/workflows/staging-test-tar-x64.yml
@@ -177,6 +177,39 @@ jobs:
           export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../anomaly-detection; pwd
           ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="es-integrationtest"
 
+  Test-Async-NoSec:
+    runs-on: ubuntu-18.04
+    name: Test-Async-NoSec
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [14]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Required Packages
+        run: release-tools/scripts/required_packages.sh
+      - name: Set up AWS Cred
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Retrieve plugin tags 
+        run:  echo "p_tag_async=$(release-tools/scripts/plugin_tag.sh opendistro-for-elasticsearch/asynchronous-search)" >> $GITHUB_ENV
+      - uses: actions/checkout@v1
+        with:
+          repository: opendistro-for-elasticsearch/asynchronous-search
+          ref: ${{env.p_tag_async}}
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: IT
+        run: |
+          release-tools/scripts/setup_runners_service.sh zip --es-nosec
+          export PATH=$JAVA_HOME:$PATH; cd $GITHUB_WORKSPACE/../asynchronous-search; pwd
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest
+
   Test-SQL:
     runs-on: ubuntu-18.04
     name: Test-SQL

--- a/.github/workflows/staging-test-windows-x64.yml
+++ b/.github/workflows/staging-test-windows-x64.yml
@@ -21,6 +21,7 @@ jobs:
       p_tag_kib_nb: ${{env.p_tag_kib_nb}}
       p_tag_sec_kibana: ${{env.p_tag_sec_kibana}}
       p_tag_alerting_kibana: ${{env.p_tag_alerting_kibana}}
+      p_tag_async: ${{env.p_tag_async}}
     steps:
       - uses: actions/checkout@v1
       - name: Get all versions and tags
@@ -36,6 +37,7 @@ jobs:
           echo "p_tag_kib_nb=$(release-tools/scripts/plugin_tag.sh opendistro-for-elasticsearch/kibana-notebooks)" >> $GITHUB_ENV
           echo "p_tag_sec_kibana=$(release-tools/scripts/plugin_tag.sh opendistro-for-elasticsearch/security-kibana-plugin)" >> $GITHUB_ENV
           echo "p_tag_alerting_kibana=$(release-tools/scripts/plugin_tag.sh opendistro-for-elasticsearch/alerting-kibana-plugin)" >> $GITHUB_ENV
+          echo "p_tag_async=$(release-tools/scripts/plugin_tag.sh opendistro-for-elasticsearch/asynchronous-search)" >> $GITHUB_ENV
 
   Test-IM-NoSec:
     needs: [Get-versions]
@@ -185,6 +187,43 @@ jobs:
           dir
           .\gradlew.bat integTest -D tests.rest.cluster=localhost:9200 -D tests.cluster=localhost:9200 -D tests.clustername="es-integrationtest"
 
+  Test-Async-NoSec:
+    needs: [Get-versions]
+    runs-on: windows-2019
+    name: Test-Async-NoSec
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [14]
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions/checkout@v1
+        with:
+           repository: opendistro-for-elasticsearch/asynchronous-search
+           ref: ${{needs.Get-versions.outputs.p_tag_async}}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Set Up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+       
+      - name: RUN ES and Async IntegTest
+        run: |
+          release-tools\scripts\setup_runners_service_windows.ps1 --es-nosec ${{needs.Get-versions.outputs.od_version}}
+          $ErrorActionPreference = 'SilentlyContinue'
+          echo running tests
+          cd ..\asynchronous-search
+          dir
+          ./gradlew.bat integTest -D tests.rest.cluster=localhost:9200 -D tests.cluster=localhost:9200 -D tests.clustername=es-integrationtest --stacktrace          
+  
   Test-SQL:
     needs: [Get-versions]
     runs-on: windows-2019


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/opendistro-for-elasticsearch/opendistro-build/issues/673

_Description of changes:_
Adds integration test for Asynchronous search plugin

_Test Results:_ 
- Docker: https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/659051242
- Windows: https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/640937606
- RPM: https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/640981415
- DEB: https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/640724858
-  Mac-os: https://github.com/opendistro-for-elasticsearch/opendistro-build/runs/2126653904?check_suite_focus=true
-  Tarball: https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/640788067

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on signing off your commits, please check here.