### PR TITLE
Change version of ODFE CLI in manifest

### DIFF
--- a/.github/workflows/staging-odfe-cli.yml
+++ b/.github/workflows/staging-odfe-cli.yml
@@ -5,6 +5,8 @@ on:
 #    - cron: '0 12 * * *'
   repository_dispatch:
     types: [staging-odfe-cli]
+  push:
+    branches: [sreekarj_odfecli]
 
 jobs:
   Test-ODFE-CLI:
@@ -35,8 +37,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: opendistro-for-elasticsearch/odfe-cli
-#          ref: ${{env.p_tag_cli}}
-          ref: main
+          ref: v${{env.p_tag_cli}}
       - name: IT
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/staging-odfe-cli.yml
+++ b/.github/workflows/staging-odfe-cli.yml
@@ -5,8 +5,6 @@ on:
 #    - cron: '0 12 * * *'
   repository_dispatch:
     types: [staging-odfe-cli]
-  push:
-    branches: [sreekarj_odfecli]
 
 jobs:
   Test-ODFE-CLI:

--- a/release-tools/scripts/manifest.yml
+++ b/release-tools/scripts/manifest.yml
@@ -295,7 +295,7 @@ plugins:
   - 
     plugin_basename: opendistro-odfe-cli
     plugin_git: opendistro-for-elasticsearch/odfe-cli
-    plugin_version: 1.0.0
+    plugin_version: 1.1.0
     plugin_build:
     plugin_spec: [linux_x64_zip,linux_arm64_zip,macos_x64_zip,windows_x64_zip,windows_x86_zip]
     plugin_category: elasticsearch-clients


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change version of ODFE CLI in manifest in regard to its release. 

*Test Results:*
https://github.com/opendistro-for-elasticsearch/opendistro-build/actions/runs/669319678

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/main/CONTRIBUTING.md#sign-your-work).
