### PR TITLE
Remove ability to run custom commands from docker-entrypoint.sh

### DIFF
--- a/elasticsearch/docker/build-image.sh
+++ b/elasticsearch/docker/build-image.sh
@@ -1,0 +1,79 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+set -e
+
+function usage() {
+    echo "This script is used to build the Open Distro for ElasticSearch Docker image. It prepares the files required by the Dockerfile in a temporary directory, then builds and tags the Docker image."
+    echo "Usage: $0 args"
+    echo "Required arguments:"
+    echo -e "-v VERSION\tSpecify the ODFE version number that you are building, e.g. '1.13.1'. This will used to label the Docker image. If you do not use the '-o' option then this tool will download a public ODFE release matching this version."
+    echo ""
+    echo "Optional arguments:"
+    echo -e "-o FILENAME\tSpecify a local ODFE tarball. You still need to specify the version - this tool does not attempt to parse the filename."
+    echo -e "-h\tPrint this message."
+}
+
+while getopts ":ho:v:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        o)
+            ODFE_TARBALL=`realpath $OPTARG`
+            ;;
+        v)
+            ODFE_VERSION=$OPTARG
+            ;;
+        :)
+            echo "-${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$ODFE_VERSION" ]; then
+    echo "You must specify '-v VERSION'"
+    usage
+    exit 1
+fi
+
+DIR=`mktemp -d`
+
+echo "Creating Docker workspace in $DIR"
+
+if [ -z "$ODFE_TARBALL" ]; then
+    # No tarball file specified so download one
+    URL="http://d3g5vo6xdbdb9a.cloudfront.net/tarball/opendistro-elasticsearch/opendistroforelasticsearch-${ODFE_VERSION}-linux-x64.tar.gz"
+    echo "Downloading ODFE version ${ODFE_VERSION} from $URL"
+    curl -f $URL -o $DIR/odfe.tgz || exit 1
+    ls -l $DIR
+else
+    cp $ODFE_TARBALL $DIR/odfe.tgz
+fi
+
+# TODO: Once https://github.com/opendistro-for-elasticsearch/opendistro-build/pull/697 is built into an ODFE release these three lines can be removed
+cp ../linux_distributions/opendistro-onetime-setup.sh $DIR/
+cp ../linux_distributions/opendistro-run.sh $DIR/
+cp ../linux_distributions/opendistro-tar-install.sh $DIR/
+
+cp config/* $DIR/
+
+docker build --build-arg ODFE_VERSION=$ODFE_VERSION --build-arg BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` -f dockerfiles/AL2.dockerfile $DIR -t odfe:$ODFE_VERSION
+
+rm -rf $DIR

--- a/elasticsearch/docker/config/docker-entrypoint.sh
+++ b/elasticsearch/docker/config/docker-entrypoint.sh
@@ -15,29 +15,6 @@ run_as_other_user_if_needed() {
     fi
 }
 
-# Allow user specify custom CMD, maybe bin/elasticsearch itself
-# for example to directly specify `-E` style parameters for elasticsearch on k8s
-# or simply to run /bin/bash to check the image
-if [[ "$1" != "eswrapper" ]]; then
-    if [[ "$(id -u)" == "0" && $(basename "$1") == "elasticsearch" ]]; then
-        # centos:7 chroot doesn't have the `--skip-chdir` option and
-        # changes our CWD.
-        # Rewrite CMD args to replace $1 with `elasticsearch` explicitly,
-        # so that we are backwards compatible with the docs
-        # from the previous Elasticsearch versions<6
-        # and configuration option D:
-        # https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docker.html#_d_override_the_image_8217_s_default_ulink_url_https_docs_docker_com_engine_reference_run_cmd_default_command_or_options_cmd_ulink
-        # Without this, user could specify `elasticsearch -E x.y=z` but
-        # `bin/elasticsearch -E x.y=z` would not work.
-        set -- "elasticsearch" "${@:2}"
-        # Use chroot to switch to UID 1000
-        exec chroot --userspec=1000 / "$@"
-    else
-        # User probably wants to run something else, like /bin/bash, with another uid forced (Openshift?)
-        exec "$@"
-    fi
-fi
-
 # Parse Docker env vars to customize Elasticsearch
 #
 # e.g. Setting the env var cluster.name=testcluster

--- a/elasticsearch/docker/config/docker-entrypoint.sh
+++ b/elasticsearch/docker/config/docker-entrypoint.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set -e
+
+# Files created by OpenDistroForElasticsearch should always be group writable too
+umask 0002
+
+run_as_other_user_if_needed() {
+    if [[ "$(id -u)" == "0" ]]; then
+        # If running as root, drop to specified UID and run command
+        exec chroot --userspec=1000 / "${@}"
+    else
+        # Either we are running in Openshift with random uid and are a member of the root group
+        # or with a custom --user
+        exec "${@}"
+    fi
+}
+
+# Allow user specify custom CMD, maybe bin/elasticsearch itself
+# for example to directly specify `-E` style parameters for elasticsearch on k8s
+# or simply to run /bin/bash to check the image
+if [[ "$1" != "eswrapper" ]]; then
+    if [[ "$(id -u)" == "0" && $(basename "$1") == "elasticsearch" ]]; then
+        # centos:7 chroot doesn't have the `--skip-chdir` option and
+        # changes our CWD.
+        # Rewrite CMD args to replace $1 with `elasticsearch` explicitly,
+        # so that we are backwards compatible with the docs
+        # from the previous Elasticsearch versions<6
+        # and configuration option D:
+        # https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docker.html#_d_override_the_image_8217_s_default_ulink_url_https_docs_docker_com_engine_reference_run_cmd_default_command_or_options_cmd_ulink
+        # Without this, user could specify `elasticsearch -E x.y=z` but
+        # `bin/elasticsearch -E x.y=z` would not work.
+        set -- "elasticsearch" "${@:2}"
+        # Use chroot to switch to UID 1000
+        exec chroot --userspec=1000 / "$@"
+    else
+        # User probably wants to run something else, like /bin/bash, with another uid forced (Openshift?)
+        exec "$@"
+    fi
+fi
+
+# Parse Docker env vars to customize Elasticsearch
+#
+# e.g. Setting the env var cluster.name=testcluster
+#
+# will cause Elasticsearch to be invoked with -Ecluster.name=testcluster
+#
+# see https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html#_setting_default_settings
+
+declare -a es_opts
+
+while IFS='=' read -r envvar_key envvar_value
+do
+    # Elasticsearch settings need to have at least two dot separated lowercase
+    # words, e.g. `cluster.name`, except for `processors` which we handle
+    # specially
+    if [[ "$envvar_key" =~ ^[a-z0-9_]+\.[a-z0-9_]+ || "$envvar_key" == "processors" ]]; then
+        if [[ ! -z $envvar_value ]]; then
+          es_opt="-E${envvar_key}=${envvar_value}"
+          es_opts+=("${es_opt}")
+        fi
+    fi
+done < <(env)
+
+# The virtual file /proc/self/cgroup should list the current cgroup
+# membership. For each hierarchy, you can follow the cgroup path from
+# this file to the cgroup filesystem (usually /sys/fs/cgroup/) and
+# introspect the statistics for the cgroup for the given
+# hierarchy. Alas, Docker breaks this by mounting the container
+# statistics at the root while leaving the cgroup paths as the actual
+# paths. Therefore, Elasticsearch provides a mechanism to override
+# reading the cgroup path from /proc/self/cgroup and instead uses the
+# cgroup path defined the JVM system property
+# es.cgroups.hierarchy.override. Therefore, we set this value here so
+# that cgroup statistics are available for the container this process
+# will run in.
+export ES_JAVA_OPTS="-Des.cgroups.hierarchy.override=/ $ES_JAVA_OPTS"
+
+if [[ "$(id -u)" == "0" ]]; then
+    # If requested and running as root, mutate the ownership of bind-mounts
+    if [[ -n "$TAKE_FILE_OWNERSHIP" ]]; then
+        chown -R 1000:0 /usr/share/elasticsearch/{data,logs}
+    fi
+fi
+
+# TODO: Replace supervisord with something else so we can certify the docker image (https://docs.docker.com/docker-hub/publish/certify-images/ says supervisord is forbidden)
+#if [[ -d "/usr/share/elasticsearch/plugins/opendistro-performance-analyzer" ]]; then
+#    CLK_TCK=`/usr/bin/getconf CLK_TCK`
+#    ES_JAVA_OPTS="-Dclk.tck=$CLK_TCK -Djdk.attach.allowAttachSelf=true $ES_JAVA_OPTS"
+#    if [[ -d "/usr/share/elasticsearch/performance-analyzer-rca" ]]; then
+#        ES_JAVA_OPTS="-Djava.security.policy=file:///usr/share/elasticsearch/performance-analyzer-rca/pa_config/es_security.policy $ES_JAVA_OPTS"
+#        /usr/bin/supervisord -c /usr/share/elasticsearch/performance-analyzer-rca/pa_config/supervisord.conf
+#    else
+#        ES_JAVA_OPTS="-Djava.security.policy=file:///usr/share/elasticsearch/plugins/opendistro-performance-analyzer/pa_config/es_security.policy $ES_JAVA_OPTS"
+#        /usr/bin/supervisord -c /usr/share/elasticsearch/plugins/opendistro-performance-analyzer/pa_config/supervisord.conf
+#    fi
+#fi
+
+run_as_other_user_if_needed /usr/share/elasticsearch/bin/elasticsearch "${es_opts[@]}"

--- a/elasticsearch/docker/config/elasticsearch.yml
+++ b/elasticsearch/docker/config/elasticsearch.yml
@@ -1,0 +1,7 @@
+cluster.name: docker-cluster
+
+# Bind to all interfaces because we don't know what IP address Docker will assign to us.
+network.host: 0.0.0.0
+
+# Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+discovery.type: single-node

--- a/elasticsearch/docker/config/log4j2.properties
+++ b/elasticsearch/docker/config/log4j2.properties
@@ -1,0 +1,9 @@
+status = error
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/opendistro-build/issues/696

*Description of changes:*
If users want to run a custom command then they can use 'docker run --entrypoint'

*Test Results:*
* Ran `build-image.sh -v 1.13.1` to download and generate odfe:1.13.1 locally.
* Ran `docker run -p 9200:9200 -p 9600:9600 --rm -it -e cluster.name=banana odfe:1.13.1` to start a single-node cluster. with no arguments. Verified that the cluster started correctly with `curl -XGET https://localhost:9200 -u 'admin:admin' --insecure`
* Ran `docker run -p 9200:9200 -p 9600:9600 --rm -it -e cluster.name=banana odfe:1.13.1 /bin/bash`. Verified that the `/bin/bash` command was ignored and the cluster started correctly with `curl -XGET https://localhost:9200 -u 'admin:admin' --insecure`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/main/CONTRIBUTING.md#sign-your-work).
