### PR TITLE
Remove ability to run custom commands from docker-entrypoint.sh

### DIFF
--- a/elasticsearch/docker/config/docker-entrypoint.sh
+++ b/elasticsearch/docker/config/docker-entrypoint.sh
@@ -15,29 +15,6 @@ run_as_other_user_if_needed() {
     fi
 }
 
-# Allow user specify custom CMD, maybe bin/elasticsearch itself
-# for example to directly specify `-E` style parameters for elasticsearch on k8s
-# or simply to run /bin/bash to check the image
-if [[ "$1" != "eswrapper" ]]; then
-    if [[ "$(id -u)" == "0" && $(basename "$1") == "elasticsearch" ]]; then
-        # centos:7 chroot doesn't have the `--skip-chdir` option and
-        # changes our CWD.
-        # Rewrite CMD args to replace $1 with `elasticsearch` explicitly,
-        # so that we are backwards compatible with the docs
-        # from the previous Elasticsearch versions<6
-        # and configuration option D:
-        # https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docker.html#_d_override_the_image_8217_s_default_ulink_url_https_docs_docker_com_engine_reference_run_cmd_default_command_or_options_cmd_ulink
-        # Without this, user could specify `elasticsearch -E x.y=z` but
-        # `bin/elasticsearch -E x.y=z` would not work.
-        set -- "elasticsearch" "${@:2}"
-        # Use chroot to switch to UID 1000
-        exec chroot --userspec=1000 / "$@"
-    else
-        # User probably wants to run something else, like /bin/bash, with another uid forced (Openshift?)
-        exec "$@"
-    fi
-fi
-
 # Parse Docker env vars to customize Elasticsearch
 #
 # e.g. Setting the env var cluster.name=testcluster


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/opendistro-build/issues/696

*Description of changes:*
If users want to run a custom command then they can use 'docker run --entrypoint'

*Test Results:*
* Ran `build-image.sh -v 1.13.1` to download and generate odfe:1.13.1 locally.
* Ran `docker run -p 9200:9200 -p 9600:9600 --rm -it -e cluster.name=banana odfe:1.13.1` to start a single-node cluster. with no arguments. Verified that the cluster started correctly with `curl -XGET https://localhost:9200 -u 'admin:admin' --insecure`
* Ran `docker run -p 9200:9200 -p 9600:9600 --rm -it -e cluster.name=banana odfe:1.13.1 /bin/bash`. Verified that the `/bin/bash` command was ignored and the cluster started correctly with `curl -XGET https://localhost:9200 -u 'admin:admin' --insecure`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/main/CONTRIBUTING.md#sign-your-work).