### PR TITLE
Move Dockerfile ARG statements so they don't bust the cache every time

### DIFF
--- a/elasticsearch/docker/dockerfiles/AL2.dockerfile
+++ b/elasticsearch/docker/dockerfiles/AL2.dockerfile
@@ -21,13 +21,11 @@
 
 FROM amazonlinux:2 AS build
 
-ARG ODFE_VERSION
-ARG BUILD_DATE
-ARG UID=1000
-ARG GID=1000
-
 # Install the tools we need: tar and gzip to unpack the ODFE tarball, and shadow-utils to give us `groupadd` and `useradd`.
 RUN yum install -y tar gzip shadow-utils
+
+ARG UID=1000
+ARG GID=1000
 
 # Create an elasticsearch user, group, and directory
 RUN groupadd -g $GID elasticsearch && \
@@ -64,6 +62,9 @@ ENTRYPOINT ["/usr/share/elasticsearch/docker-entrypoint.sh"]
 CMD ["eswrapper"]
 
 # Label
+ARG ODFE_VERSION
+ARG BUILD_DATE
+
 LABEL org.label-schema.schema-version="1.0" \
   org.label-schema.name="opendistroforelasticsearch" \
   org.label-schema.version="$ODFE_VERSION" \


### PR DESCRIPTION
*Description of changes:*
The BUILD_DATE arg changes every build and breaks the cache. Moving the ARGs to just before they're needed minimizes the amount of cache-busting that goes on.

*Test Results:* Ran the build twice, verified that the second one used the cache.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/main/CONTRIBUTING.md#sign-your-work).
