### PR TITLE
Replace supervisord with bash job control so that we can certify the AmazonLinux Docker image

### DIFF
--- a/elasticsearch/docker/config/performance-analyzer.properties
+++ b/elasticsearch/docker/config/performance-analyzer.properties
@@ -1,0 +1,25 @@
+## Paths
+# metrics-location is the shared memory location where the plugin will write metrics, and the agent will read
+metrics-location = /dev/shm/performanceanalyzer/
+# The agent digests data coming from shared memory and indexes it into files stored in metrics-db-file-prefix-path
+metrics-db-file-prefix-path = /tmp/metricsdb_
+# Location of logs for the plugin and agent (the word 'metadata' here is misleading; they're just logs)
+plugin-stats-metadata = plugin-stats-metadata
+agent-stats-metadata = agent-stats-metadata
+
+## Config for the agent webservice.
+webservice-listener-port = 9600
+# Binding to 0.0.0.0 is important because we don't know what IP address Docker will give us. 0.0.0.0 will bind to all interfaces.
+webservice-bind-host=0.0.0.0
+
+## Cleanup
+# The agent will clean up old index files if this is enabled
+cleanup-metrics-db-files = true
+# Maximum age of old index files in minutes
+metrics-deletion-interval = 1
+
+## Https
+# Disable https. If you enable this, make sure the certificate and private key paths point to real files.
+https-enabled = false
+certificate-file-path = none
+private-key-file-path = none

--- a/elasticsearch/docker/dockerfiles/AL2.dockerfile
+++ b/elasticsearch/docker/dockerfiles/AL2.dockerfile
@@ -39,6 +39,7 @@ RUN tar -xzf /tmp/elasticsearch/odfe.tgz -C /usr/share/elasticsearch --strip-com
 COPY log4j2.properties /usr/share/elasticsearch/config/
 COPY elasticsearch.yml /usr/share/elasticsearch/config/
 COPY docker-entrypoint.sh /usr/share/elasticsearch/
+COPY performance-analyzer.properties /usr/share/elasticsearch/plugins/opendistro-performance-analyzer/pa_config/
 
 # TODO: Temporary, until we get changes to opendistro-tar-install.sh built into ODFE
 # Once https://github.com/opendistro-for-elasticsearch/opendistro-build/pull/697 is built into the next version of ODFE and we have a tarball we can delete the next three lines


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/opendistro-build/issues/696

*Description of changes:*
Rip out the supervisord stuff from the docker-entrypoint.sh script and replace it with bash job control.

The entry point starts up the elasticsearch and performance analyzer processes, then waits. If either process terminates then the other one is killed and the container exits. If a SIGTERM (e.g. from `docker container stop`) or SIGINT (e.g. from a ctrl-c) is sent to the script then it will kill both processes.

The idea here is that the container environment is responsible for spinning up a new container instance if the old one fails. There is no need to run supervisord within the container to restart processes.

The performance analyzer startup command is taken from the [tarball installation documentation](https://opendistro.github.io/for-elasticsearch-docs/docs/install/tar/). Note that the official documentation is different to the what the old Docker entrypoint script did.

*Test Results:*
Started a container and verified that performance analyzer was available and generating data.

Tried the following scenarios:
* ctrl-c to terminate the script. Both processes are killed; container exits.
* performance-analyzer fails to start (e.g. by omitting the ES_HOME variable). Elasticsearch process is killed; container exits.
* Manually kill elasticsearch process. Performance analyzer is automatically killed; container exits.
* Manually kill performance analyzer process. Elasticsearch is automatically killed; container exits.

Verified that performance analyzer generates data by creating an index and adding 500 random documents, then querying 100 times. Results of running `curl "http://localhost:9600/_opendistro/_performanceanalyzer/metrics?metrics=Latency,CPU_Utilization&agg=avg,max&dim=ShardID&nodes=all"` several times during this process:
* `{"byvPP88BQjOL3ZS9u19Lcw": {"timestamp": 1617298425000, "data": {"fields":[{"name":"ShardID","type":"VARCHAR"},{"name":"Latency","type":"DOUBLE"},{"name":"CPU_Utilization","type":"DOUBLE"}],"records":[[null,2.93820224719101,0.21469191665666867],["0",10.444607843137254,0.009318904357996325]]}}}`
* `{"byvPP88BQjOL3ZS9u19Lcw": {"timestamp": 1617298430000, "data": {"fields":[{"name":"ShardID","type":"VARCHAR"},{"name":"Latency","type":"DOUBLE"},{"name":"CPU_Utilization","type":"DOUBLE"}],"records":[[null,4.44919786096257,0.32098540291941613],["0",3.88770053475936,0.010378492043526779]]}}}`
* `{"byvPP88BQjOL3ZS9u19Lcw": {"timestamp": 1617298435000, "data": {"fields":[{"name":"ShardID","type":"VARCHAR"},{"name":"Latency","type":"DOUBLE"},{"name":"CPU_Utilization","type":"DOUBLE"}],"records":[[null,4.21022727272727,0.31995160967806435],["0",3.55113636363636,0.007911461186023663]]}}}`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/main/CONTRIBUTING.md#sign-your-work).
