### PR TITLE
Added support for shard allocation awareness by zone and forced awareness in Helm chart

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -629,7 +629,7 @@ The following table lists the configurable parameters of the opendistro elastics
 | `elasticsearch.extraVolumeMounts`                         | Array of extra volume mounts to be added                                                                                                                 | `[]`                                                                    |
 | `elasticsearch.extraInitContainers`                       | Array of extra init containers                                                                                                                           | `[]`                                                                    |
 | `elasticsearch.enableShardAllocationAwareness`            | Awareness of allocation of shards by zone                                                                                                                | `false`                                                                 |
-| `elasticsearch.forcedAllocationAwareness`                 | Forced awareness of allocation of shards                                                                                                                 | `false`                                                                 |
+| `elasticsearch.forcedAllocationAwareness`                 | Forced awareness of allocation of shards. This will only become active when `enableShardAllocationAwareness` is enabled                                  | `false`                                                                 |
 
 ## Acknowledgements
 * [Kalvin Chau](https://github.com/kalvinnchau) (Software Engineer - Viasat) for all his help with the Kubernetes internals, certs, and debugging

--- a/helm/README.md
+++ b/helm/README.md
@@ -628,6 +628,8 @@ The following table lists the configurable parameters of the opendistro elastics
 | `elasticsearch.extraVolumes`                              | Array of extra volumes to be added                                                                                                                       | `[]`                                                                    |
 | `elasticsearch.extraVolumeMounts`                         | Array of extra volume mounts to be added                                                                                                                 | `[]`                                                                    |
 | `elasticsearch.extraInitContainers`                       | Array of extra init containers                                                                                                                           | `[]`                                                                    |
+| `elasticsearch.enableShardAllocationAwareness`            | Awareness of allocation of shards by zone                                                                                                                | `false`                                                                 |
+| `elasticsearch.forcedAllocationAwareness`                 | Forced awareness of allocation of shards                                                                                                                 | `false`                                                                 |
 
 ## Acknowledgements
 * [Kalvin Chau](https://github.com/kalvinnchau) (Software Engineer - Viasat) for all his help with the Kubernetes internals, certs, and debugging

--- a/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -74,6 +74,25 @@ spec:
             name: data
             subPath: {{ .Values.elasticsearch.data.persistence.subPath }}
 {{- end }}
+{{ if .Values.elasticsearch.enableShardAllocationAwareness }}
+      - name: get-zone
+        image: {{ .Values.global.imageRegistry }}/bskim45/helm-kubectl-jq
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+        volumeMounts:
+          - mountPath: /tmpConfig
+            name: tmp
+        command:
+          - bash
+          - -c
+          - |
+            set -ex
+            ZONE=$(kubectl get node $NODE_NAME -o json | jq -r '.metadata.labels["failure-domain.beta.kubernetes.io/zone"]'); 
+            echo $ZONE > /tmpConfig/es-zone
+{{- end }}
 {{- if .Values.elasticsearch.extraInitContainers }}
 {{ toYaml .Values.elasticsearch.extraInitContainers| indent 6 }}
 {{- end }}
@@ -92,6 +111,14 @@ spec:
 {{- if .Values.elasticsearch.sys_chroot.enabled }}
           capabilities:
             add: ["SYS_CHROOT"]
+{{- end }}
+{{ if .Values.elasticsearch.enableShardAllocationAwareness }}
+        command:
+          - bash
+          - -c
+          - |
+            set -ex
+            env "node.attr.zone=$(</tmpConfig/es-zone)" /usr/local/bin/docker-entrypoint.sh eswrapper
 {{- end }}
         env:
         - name: cluster.name
@@ -145,6 +172,10 @@ spec:
 {{ toYaml . | indent 10 }}
     {{- end }}
         volumeMounts:
+{{ if .Values.elasticsearch.enableShardAllocationAwareness }}
+        - name: tmp
+          mountPath: /tmpConfig
+{{- end }}
         - mountPath: /usr/share/elasticsearch/data
           name: data
           subPath: {{ .Values.elasticsearch.data.persistence.subPath }}
@@ -198,6 +229,10 @@ spec:
 {{ toYaml .Values.elasticsearch.extraVolumeMounts | indent 8 }}
 {{- end }}
       volumes:
+{{ if .Values.elasticsearch.enableShardAllocationAwareness }}
+      - name: tmp
+        emptyDir: { }
+{{- end }}
       - name: config
         secret:
           secretName: {{ template "opendistro-es.fullname" . }}-es-config

--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -79,6 +79,29 @@ spec:
             name: data
             subPath: {{ .Values.elasticsearch.master.persistence.subPath }}
 {{- end }}
+{{ if .Values.elasticsearch.enableShardAllocationAwareness }}
+      - name: get-zone
+        image: {{ .Values.global.imageRegistry }}/bskim45/helm-kubectl-jq
+        env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+        volumeMounts:
+          - mountPath: /tmpConfig
+            name: tmp
+        command:
+          - bash
+          - -c
+          - |
+            set -ex
+            ZONE=$(kubectl get node $NODE_NAME -o json | jq -r '.metadata.labels["failure-domain.beta.kubernetes.io/zone"]'); 
+            echo $ZONE > /tmpConfig/es-zone
+{{ if .Values.elasticsearch.forcedAllocationAwareness }}
+            ZONES=$(kubectl get node -o json | jq -r '.items[].metadata.labels["failure-domain.beta.kubernetes.io/zone"]' | sort -u | paste -d, -s)
+            echo $ZONES > /tmpConfig/es-zones
+{{- end }}
+{{- end }}
 {{- if .Values.elasticsearch.extraInitContainers }}
 {{ toYaml .Values.elasticsearch.extraInitContainers| indent 6 }}
 {{- end }}
@@ -95,6 +118,21 @@ spec:
         securityContext:
           capabilities:
             add: ["SYS_CHROOT"]
+{{- end }}
+{{ if .Values.elasticsearch.enableShardAllocationAwareness }}
+        command:
+          - bash
+          - -cx
+          - |
+            set -ex
+{{ if .Values.elasticsearch.forcedAllocationAwareness }}
+            CONFIG_FILE=config/elasticsearch.yml
+            CONFIG_FILE_BACKUP=config/elasticsearch.yml.backup
+            mv $CONFIG_FILE $CONFIG_FILE_BACKUP
+            echo cluster.routing.allocation.awareness.force.zone.values: $(</tmpConfig/es-zones) >> $CONFIG_FILE_BACKUP
+            mv $CONFIG_FILE_BACKUP $CONFIG_FILE
+{{- end }}
+            env "node.attr.zone=$(</tmpConfig/es-zone)" /usr/local/bin/docker-entrypoint.sh eswrapper
 {{- end }}
         env:
         - name: cluster.name
@@ -141,6 +179,10 @@ spec:
               resource: limits.cpu
         - name: ES_JAVA_OPTS
           value: {{ .Values.elasticsearch.master.javaOpts }}
+{{ if .Values.elasticsearch.enableShardAllocationAwareness }}
+        - name: cluster.routing.allocation.awareness.attributes
+          value: zone
+{{- end }}
 {{- if .Values.elasticsearch.extraEnvs }}
 {{ toYaml .Values.elasticsearch.extraEnvs | indent 8 }}
 {{- end }}
@@ -171,6 +213,10 @@ spec:
         - containerPort: 9650
           name: rca
         volumeMounts:
+{{ if .Values.elasticsearch.enableShardAllocationAwareness }}
+        - name: tmp
+          mountPath: /tmpConfig
+{{- end }}
         - mountPath: /usr/share/elasticsearch/data
           name: data
           subPath: {{ .Values.elasticsearch.master.persistence.subPath }}
@@ -263,6 +309,10 @@ spec:
 {{ toYaml .Values.elasticsearch.master.extraContainers | indent 6 }}
 {{- end }}
       volumes:
+{{ if .Values.elasticsearch.enableShardAllocationAwareness }}
+      - name: tmp
+        emptyDir: {}
+{{- end }}
       - name: config
         secret:
           secretName: {{ template "opendistro-es.fullname" . }}-es-config

--- a/helm/opendistro-es/templates/elasticsearch/role.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/role.yaml
@@ -26,4 +26,17 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "opendistro-es.fullname" . }}-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: get-nodes
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
 {{- end }}

--- a/helm/opendistro-es/templates/elasticsearch/rolebinding.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/rolebinding.yaml
@@ -27,4 +27,18 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "opendistro-es.elasticsearch.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "opendistro-es.fullname" . }}-elastic-clusterrolebinding
+  namespace: default
+subjects:
+  - kind: User
+    name: system:serviceaccount:default:{{ template "opendistro-es.elasticsearch.serviceAccountName" . }}
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: get-nodes
+  apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 
 kibana:
-  enabled: true
+  enabled: false
   image: amazon/opendistro-for-elasticsearch-kibana
   imageTag: 1.13.1
   ## Specifies the image pull policy. Can be "Always" or "IfNotPresent" or "Never".
@@ -550,6 +550,13 @@ elasticsearch:
     ## The name of the ServiceAccount to use.
     ## If not set and create is true, a name is generated using the fullname template
     name:
+
+  ## Awareness attribute that uses zone configuration when allocating shards
+  enableShardAllocationAwareness: false
+  
+  ## By default, if one location fails, Elasticsearch assigns all of the missing replica shards to the remaining locations. 
+  ## To prevent a single location from being overloaded in the event of a failure, you can set this to true
+  forcedAllocationAwareness: false
 
 
 nameOverride: ""

--- a/release-tools/scripts/manifest.yml
+++ b/release-tools/scripts/manifest.yml
@@ -5,9 +5,9 @@ versions:
     current: 7.10.2
     next: 7.10.3
   ODFE:
-    previous: 1.13.0
-    current: 1.13.1
-    next: 1.13.2
+    previous: 1.13.1
+    current: 1.13.2
+    next: 1.13.3
 
 urls:
   ES: 
@@ -28,7 +28,7 @@ urls:
     prod: s3://artifacts.opendistroforelasticsearch.amazon.com/
     #snapshots: s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/
     releases: s3://staging.artifacts.opendistroforelasticsearch.amazon.com/releases/
-    releases_final_build: rc-build-615364781
+    releases_final_build: 
 
 # Warning:
 # Please do not change the plugin orders as they have dependencies
@@ -257,7 +257,7 @@ plugins:
     plugin_build: 
     plugin_spec: [noplatform_noarch_zip]
     plugin_category: kibana-plugins
-    release_candidate: false
+    release_candidate: true
     plugin_location_staging: [default: "s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/kibana-plugins/trace-analytics/"]
     plugin_location_prod: [default: "s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/kibana-plugins/opendistro-trace-analytics/"]
   - 

--- a/release-tools/scripts/manifest.yml
+++ b/release-tools/scripts/manifest.yml
@@ -39,8 +39,8 @@ plugins:
   - 
     plugin_basename: opendistro-sql
     plugin_git: opendistro-for-elasticsearch/sql
-    plugin_version: 1.13.0.0
-    plugin_build: 37
+    plugin_version: 1.13.2.0
+    plugin_build: 41
     plugin_spec: [noplatform_noarch_zip,noplatform_noarch_deb,noplatform_noarch_rpm]
     plugin_category: elasticsearch-plugins
     release_candidate: true
@@ -99,8 +99,8 @@ plugins:
   - 
     plugin_basename: opendistro-index-management
     plugin_git: opendistro-for-elasticsearch/index-management
-    plugin_version: 1.13.1.0
-    plugin_build: 15
+    plugin_version: 1.13.2.0
+    plugin_build: 16
     plugin_spec: [noplatform_noarch_zip,noplatform_noarch_deb,noplatform_noarch_rpm]
     plugin_category: elasticsearch-plugins
     release_candidate: true
@@ -171,8 +171,8 @@ plugins:
   - 
     plugin_basename: opendistroQueryWorkbenchKibana
     plugin_git: opendistro-for-elasticsearch/sql
-    plugin_version: 1.13.0.0
-    plugin_build: 31
+    plugin_version: 1.13.2.0
+    plugin_build: 34
     plugin_spec: [noplatform_noarch_zip]
     plugin_category: kibana-plugins
     release_candidate: true
@@ -221,8 +221,8 @@ plugins:
   - 
     plugin_basename: opendistroNotebooksKibana
     plugin_git: opendistro-for-elasticsearch/kibana-notebooks
-    plugin_version: 1.13.0.0
-    plugin_build: 11
+    plugin_version: 1.13.2.0
+    plugin_build: 14
     plugin_spec: [noplatform_noarch_zip]
     plugin_category: kibana-plugins
     release_candidate: true
@@ -241,8 +241,8 @@ plugins:
   - 
     plugin_basename: opendistroReportsKibana
     plugin_git: opendistro-for-elasticsearch/kibana-reports
-    plugin_version: 1.13.0.0
-    plugin_build: 18
+    plugin_version: 1.13.2.0
+    plugin_build: 21
     plugin_spec: [linux_x64_zip,linux_arm64_zip,windows_x64_zip]
     plugin_category: kibana-plugins
     release_candidate: true
@@ -253,8 +253,8 @@ plugins:
   - 
     plugin_basename: opendistroTraceAnalyticsKibana
     plugin_git: opendistro-for-elasticsearch/trace-analytics
-    plugin_version: 1.13.0.0
-    plugin_build: 
+    plugin_version: 1.13.2.0
+    plugin_build: 11
     plugin_spec: [noplatform_noarch_zip]
     plugin_category: kibana-plugins
     release_candidate: true


### PR DESCRIPTION
*Issue:*

https://github.com/opendistro-for-elasticsearch/opendistro-build/issues/728

*Description of changes:*

Added support for Shard Allocation Awareness by Zone and Forced Allocation Awareness of the shards by zones.

*Test Results:*

Manual testing done by checking for the added configuration properties in the `_nodes` endpoint. 

By enabling `elasticsearch.enableShardAllocationAwareness`, we see that the following properties have been added:
- `node.attr.zone`: <ZONE>. If there is no zone configuration, then this value will be `0`.
- `cluster.routing.allocation.awareness.attributes: zone`

By enabling `elasticsearch.forcedAllocationAwareness`, we see that the following propery has also been added:
- `cluster.routing.allocation.awareness.force.zone.values: <ZONES>`, where `<ZONES>` is a CSV of all zones configured within the node pools. 

By disabling `elasticsearch.enableShardAllocationAwareness`, we don't see any of the above properties being added.

By disabling `elasticsearch.enableShardAllocationAwareness` and only enabling `elasticsearch.forcedAllocationAwareness`, we don't see any of the above properties being added.
