### PR TITLE
Added default value to securityConfigSecret to fix issue #702

### DIFF
--- a/helm/opendistro-es/values-nonroot.yaml
+++ b/helm/opendistro-es/values-nonroot.yaml
@@ -174,7 +174,7 @@ elasticsearch:
     #The following option simplifies securityConfig by using a single secret and specifying the respective secrets in the corresponding files instead of creating different secrets for config,internal users, roles, roles mapping and tenants
     #Note that this is an alternative to the above secrets and shouldn't be used if the above secrets are used
     config:
-       securityConfigSecret:
+       securityConfigSecret: security-configs-secret
        data: {}
         # config.yml: |-
         # internal_users.yml: |-

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -172,7 +172,7 @@ elasticsearch:
     #The following option simplifies securityConfig by using a single secret and specifying the respective secrets in the corresponding files instead of creating different secrets for config,internal users, roles, roles mapping and tenants
     #Note that this is an alternative to the above secrets and shouldn't be used if the above secrets are used
     config:
-      securityConfigSecret:
+      securityConfigSecret: security-configs-secret
       data: {}
        # config.yml: |-
        # internal_users.yml: |-


### PR DESCRIPTION
Signed-off-by: David Calvert <davidcalvertfr@gmail.com>

*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/opendistro-build/issues/702

*Description of changes:* Added a default value to securityConfigSecret to make this feature work straight away. I didn't find any instructions on bumping the chart version so I left it unchanged. Let me know if you want me to bump it in this PR.

*Test Results:* 

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/main/CONTRIBUTING.md#sign-your-work).
