### PR TITLE
Add data prepper 1.0.0 version for releases

### DIFF
--- a/release-tools/scripts/manifest.yml
+++ b/release-tools/scripts/manifest.yml
@@ -319,7 +319,7 @@ plugins:
   -
     plugin_basename: opendistroforelasticsearch-data-prepper
     plugin_git: opendistro-for-elasticsearch/data-prepper
-    plugin_version: 0.8.0-beta
+    plugin_version: 1.0.0
     plugin_build:
     plugin_spec: [linux_x64_tar.gz,linux_x64_zip,macos_x64_tar.gz,macos_x64_zip]
     plugin_category: elasticsearch-clients


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

*Issue #, if available:*
#745 

*Description of changes:*
This PR is to add data prepper 1.0.0 version for releases

*Test Results:*
No Need

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/main/CONTRIBUTING.md#sign-your-work).
