### PR TITLE
Kibana securitycontext

### DIFF
--- a/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
+++ b/helm/opendistro-es/templates/kibana/kibana-deployment.yaml
@@ -46,6 +46,10 @@ spec:
       initContainers:
 {{ toYaml .Values.kibana.extraInitContainers | indent 8 }}
 {{- end }}
+{{- with .Values.kibana.securityContextCustom }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
       containers:
       - env:
         - name: CLUSTER_NAME

--- a/helm/opendistro-es/values-nonroot.yaml
+++ b/helm/opendistro-es/values-nonroot.yaml
@@ -37,6 +37,12 @@ kibana:
     keyPassphrase:
       enabled: false
 
+  ## securityContext to apply to the pod. Allows for running as non-root
+  securityContextCustom:
+   fsGroup: 1000
+   runAsUser: 1000
+   runAsGroup: 1000
+
   extraEnvs: []
 
   extraVolumes: []

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -37,6 +37,12 @@ kibana:
     keyPassphrase:
       enabled: false
 
+  ## securityContext to apply to the pod. Allows for running as non-root
+  securityContextCustom: {}
+  #  fsGroup: 1000
+  #  runAsUser: 1000
+  #  runAsGroup: 1000
+
   extraEnvs: []
 
   extraVolumes: []


### PR DESCRIPTION
*Issue #, if available:* #555 (partly)

*Description of changes:* Similar to #703, this change adds a value to the Helm template to allow setting a securityContext on Kibana containers under the key `kibana.securityContextCustom`

Example settings are added to the `values-nonroot.yaml` file.

*Test Results:*

Tested on a production cluster via helm-cli

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/main/CONTRIBUTING.md#sign-your-work).
