### PR TITLE
Update the whitesource scan to run every 2 hours

### DIFF
--- a/.github/workflows/check-vulnerability-whitesource.yml
+++ b/.github/workflows/check-vulnerability-whitesource.yml
@@ -2,7 +2,7 @@ name: WhiteSource Vulnerability Scan
 
 on:
   schedule:
-    - cron: '30 10 * * *'
+    - cron: '0 */2 * * *'
   repository_dispatch:
     types: [check-vulnerability-whitesource]
 


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

*Description of changes:*
Change the WhiteSource CVEs scan from once a day to run every 2 hours. 

*Test Results:*

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/main/CONTRIBUTING.md#sign-your-work).
